### PR TITLE
fix: import Webhook in webhook route

### DIFF
--- a/src/routes/webhook.js
+++ b/src/routes/webhook.js
@@ -1,5 +1,5 @@
 // TODO: Make this import dynamic, so that we can add new controllers without repeating ourselves.
-import Webhook from "../controllers/webhooks";
+import Webhook from "../controllers/webhook";
 
 export default class WebhookRoutes {
   static register(webhook) {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Corrects import path for Webhook controller

- Fixes module resolution in webhook route


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>webhook.js</strong><dd><code>Fix import path for Webhook controller</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/routes/webhook.js

<li>Changes import from <code>webhooks</code> to <code>webhook</code> controller<br> <li> Resolves incorrect import path for Webhook


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/4/files#diff-2bc537e1e697f47c248e481a281b6c029d8fdc8bbe610a04ab7cc59284e9c073">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>