### PR TITLE
ignore event type which is not messaging

### DIFF
--- a/src/controllers/webhook/pancake/erp/message.js
+++ b/src/controllers/webhook/pancake/erp/message.js
@@ -4,7 +4,9 @@ export default class PancakeERPMessageController {
   static async create(ctx) {
     const data = await ctx.req.json();
     try {
-      await ctx.env["MESSAGE_QUEUE"].send(data);
+      if (data.event_type === "messaging") {
+        await ctx.env["MESSAGE_QUEUE"].send(data);
+      }
       return ctx.json({ message: "Message Received" });
     } catch {
       throw new HTTPException(500, "Failed to send message to queue");

--- a/src/services/pancake/conversation/conversation.js
+++ b/src/services/pancake/conversation/conversation.js
@@ -176,8 +176,6 @@ export default class ConversationService {
     const { data } = body;
     const { message } = data;
 
-    if (body?.event_type !== "messaging") { return; }
-
     // Skip if the message is from admin
     if (message?.from?.admin_id) { return; }
 

--- a/src/services/pancake/conversation/conversation.js
+++ b/src/services/pancake/conversation/conversation.js
@@ -176,6 +176,8 @@ export default class ConversationService {
     const { data } = body;
     const { message } = data;
 
+    if (body?.event_type !== "messaging") { return; }
+
     // Skip if the message is from admin
     if (message?.from?.admin_id) { return; }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add event type filtering to skip non-messaging events

- Prevent processing of events that aren't messaging type


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Incoming Event"] --> B["Check event_type"]
  B --> C{"event_type === 'messaging'?"}
  C -->|No| D["Return Early"]
  C -->|Yes| E["Continue Processing"]
  E --> F["Check Admin Message"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conversation.js</strong><dd><code>Add messaging event type validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/pancake/conversation/conversation.js

<li>Added early return condition to filter out non-messaging events<br> <li> Prevents processing of events where <code>event_type</code> is not "messaging"


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/47/files#diff-b28b4bfd8d4d966a284724958139ccd83044671939c6c97568245ad3fec38c2a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>