### PR TITLE
fix: use subquery to avoid duplicates variants

### DIFF
--- a/src/services/ecommerce/product/product.js
+++ b/src/services/ecommerce/product/product.js
@@ -36,18 +36,36 @@ export default class ProductService {
     const likePattern = `%${lowerSearchKey}%`;
     const result = await this.db.$queryRaw`
     SELECT  
-      CAST(p.haravan_product_id AS INT) AS id,
-      p.title,
-      d.design_code,
-      p.handle,
-      d.diamond_holder,
-      d.ring_band_type,
-      p.haravan_product_type AS product_type,
-      CASE 
-        WHEN e.product_id IS NULL THEN FALSE 
-        ELSE TRUE 
-      END AS has_360,
-      array_agg(i.src ORDER BY i.src) AS images,
+  CAST(p.haravan_product_id AS INT) AS id,
+  p.title,
+  d.design_code,
+  p.handle,
+  d.diamond_holder,
+  d.ring_band_type,
+  p.haravan_product_type AS product_type,
+  CASE 
+    WHEN e.product_id IS NULL THEN FALSE 
+    ELSE TRUE 
+  END AS has_360,
+  img.images,
+  var.variants
+FROM ecom.products p
+  INNER JOIN workplace.designs d ON d.id = p.design_id
+  LEFT JOIN workplace.ecom_360 e ON p.workplace_id = e.product_id
+
+  -- Subquery for pre-aggregated images
+  INNER JOIN (
+    SELECT 
+      i.product_id,
+      array_agg(i.src ORDER BY i.src) AS images
+    FROM haravan.images i
+    GROUP BY i.product_id
+  ) img ON img.product_id = p.haravan_product_id
+
+  -- Subquery for pre-aggregated variants
+  INNER JOIN (
+    SELECT 
+      v.hararvan_product_id,
       JSON_AGG(
         JSON_BUILD_OBJECT(
           'id', CAST(v.haravan_variant_id AS INT),
@@ -58,25 +76,13 @@ export default class ProductService {
           'price_compare_at', CAST(v.price_compare_at AS INT)
         )
       ) AS variants
-    FROM ecom.products p
-      INNER JOIN workplace.designs d ON d.id = p.design_id
-      LEFT JOIN workplace.ecom_360 e ON p.workplace_id = e.product_id
-      INNER JOIN haravan.images i ON i.product_id = p.haravan_product_id
-      INNER JOIN LATERAL (
-        SELECT *
-        FROM ecom.variants v
-        WHERE v.hararvan_product_id = p.haravan_product_id
-      ) v ON TRUE
-    WHERE 1 = 1
-    AND lower(concat(p.title, d.design_code, p.haravan_product_type )) LIKE ${likePattern}
-    GROUP BY 
-      p.haravan_product_id, p.title, d.design_code, p.handle, 
-      d.diamond_holder, d.ring_band_type, p.haravan_product_type,
-      CASE WHEN e.product_id IS NULL THEN FALSE ELSE TRUE END,
-      p.max_price, p.min_price, p.max_price_18, p.max_price_14, 
-      p.qty_onhand, p.image_updated_at
-    LIMIT ${limit};
+    FROM ecom.variants v
+    GROUP BY v.hararvan_product_id
+  ) var ON var.hararvan_product_id = p.haravan_product_id
+
+WHERE lower(concat(p.title, d.design_code, p.haravan_product_type)) LIKE ${likePattern}
+LIMIT ${limit};
     `;
-    return result;
+    return result;  
   }
 }


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Refactored SQL query to use subqueries for images and variants

- Eliminated duplicate results by pre-aggregating data

- Improved query performance and data consistency

- Removed unnecessary GROUP BY clause and LATERAL join


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Original Query"] --> B["LATERAL Join"]
  B --> C["Duplicate Results"]
  D["Refactored Query"] --> E["Subqueries"]
  E --> F["Pre-aggregated Data"]
  F --> G["No Duplicates"]
  A --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>product.js</strong><dd><code>Refactor SQL query with subqueries to eliminate duplicates</code></dd></summary>
<hr>

src/services/ecommerce/product/product.js

<ul><li>Replaced LATERAL join with subqueries for images and variants<br> <li> Pre-aggregated images and variants data to avoid duplicates<br> <li> Simplified main query structure and removed complex GROUP BY<br> <li> Maintained same output format while improving performance</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/64/files#diff-66d2a40f1336a4675a0d216f637a7467a589fc8e6db3620d4a4311e5bbab971a">+37/-31</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

