### PR TITLE
add format-template-zalo

### DIFF
--- a/src/services/ecommerce/zalo-message/utils/format-template-zalo.js
+++ b/src/services/ecommerce/zalo-message/utils/format-template-zalo.js
@@ -19,9 +19,9 @@ export class GetTemplateZalo {
   static convertPhoneNumber(phone) {
     if (!phone) return null;
 
-    if (phone.startsWith("0")) return `+84${phone.slice(1)}`;
-    else if (phone.startsWith("84")) return `+${phone}`;
-    else if (phone.startsWith("+84")) return phone;
+    if (phone.startsWith("0")) return `84${phone.slice(1)}`;
+    else if (phone.startsWith("84")) return phone;
+    else if (phone.startsWith("+84")) return `${phone.slice(1)}`;
     return null;
   }
 }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix phone number format conversion for Zalo messaging

- Remove '+' prefix from phone numbers in conversion logic

- Standardize phone number format to use '84' country code


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Phone Input"] --> B["convertPhoneNumber()"]
  B --> C["Remove '+' prefix"]
  C --> D["Standardized '84' format"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>format-template-zalo.js</strong><dd><code>Fix phone number format conversion logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/ecommerce/zalo-message/utils/format-template-zalo.js

<ul><li>Modified phone number conversion logic to remove '+' prefix<br> <li> Updated format to use '84' country code without plus sign<br> <li> Fixed handling of different phone number input formats</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/120/files#diff-f3ca059ff07d45b121cb8375c606123fd2d9b483936969db15ab29dfda9cb437">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

