### PR TITLE
feat(erp-sales-order): add carrier_status field

### DIFF
--- a/src/services/erp/selling/sales-order/sales-order.js
+++ b/src/services/erp/selling/sales-order/sales-order.js
@@ -41,6 +41,12 @@ export default class SalesOrderService {
       refunded: "Refunded",
       pending: "Pending"
     };
+    this.carrierStatusMapper = {
+      notdelivered: "Not Delivered",
+      readytopick: "Ready To Pick",
+      delivering: "Delivering",
+      delivered: "Delivered"
+    };
     this.frappeClient = new FrappeClient(
       {
         url: env.JEMMIA_ERP_BASE_URL,
@@ -92,6 +98,7 @@ export default class SalesOrderService {
       financial_status: this.financialStatusMapper[haravanOrderData.financial_status],
       fulfillment_status: this.fulfillmentStatusMapper[haravanOrderData.fulfillment_status],
       cancelled_status: this.cancelledStatusMapper[haravanOrderData.cancelled_status],
+      carrier_status: haravanOrderData.carrier_status ? this.carrierStatusMapper[haravanOrderData.carrier_status] : this.carrierStatusMapper.notdelivered,
       transaction_date: convertIsoToDatetime(haravanOrderData.created_at, "date"),
       haravan_created_at: convertIsoToDatetime(haravanOrderData.created_at, "datetime"),
       total: haravanOrderData.total_line_items_price,


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add carrier status mapping functionality to sales order service

- Map Haravan carrier status to ERP-friendly format

- Set default "Not Delivered" status when carrier status is missing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Haravan Order Data"] --> B["Carrier Status Mapper"]
  B --> C["ERP Sales Order"]
  B --> D["Default: Not Delivered"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sales-order.js</strong><dd><code>Add carrier status mapping functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/erp/selling/sales-order/sales-order.js

<ul><li>Add <code>carrierStatusMapper</code> with four status mappings<br> <li> Include <code>carrier_status</code> field in sales order data mapping<br> <li> Set default "Not Delivered" when carrier status is missing</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/184/files#diff-4c0efcc4b18a631929662e2a5a0a5fca5e19181215caeefab2a0221b5768e4f6">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

