### PR TITLE
fix(erp-sales-order): wrong attribute path for carrier status

### DIFF
--- a/src/services/erp/selling/sales-order/sales-order.js
+++ b/src/services/erp/selling/sales-order/sales-order.js
@@ -98,7 +98,7 @@ export default class SalesOrderService {
       financial_status: this.financialStatusMapper[haravanOrderData.financial_status],
       fulfillment_status: this.fulfillmentStatusMapper[haravanOrderData.fulfillment_status],
       cancelled_status: this.cancelledStatusMapper[haravanOrderData.cancelled_status],
-      carrier_status: haravanOrderData.carrier_status_code ? this.carrierStatusMapper[haravanOrderData.carrier_status_code] : this.carrierStatusMapper.notdelivered,
+      carrier_status: haravanOrderData.fulfillments.length ? this.carrierStatusMapper[haravanOrderData.fulfillments[0].carrier_status_code] : this.carrierStatusMapper.notdelivered,
       transaction_date: convertIsoToDatetime(haravanOrderData.created_at, "date"),
       haravan_created_at: convertIsoToDatetime(haravanOrderData.created_at, "datetime"),
       total: haravanOrderData.total_line_items_price,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix incorrect attribute path for carrier status mapping

- Change from direct property to nested fulfillment array access


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["haravanOrderData"] --> B["carrier_status_code (old)"]
  A --> C["fulfillments[0].carrier_status_code (new)"]
  B --> D["carrierStatusMapper"]
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sales-order.js</strong><dd><code>Fix carrier status attribute path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/erp/selling/sales-order/sales-order.js

<ul><li>Updated carrier status mapping to access <code>carrier_status_code</code> from <br><code>fulfillments[0]</code> instead of root level<br> <li> Added length check for fulfillments array before accessing first <br>element</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/193/files#diff-4c0efcc4b18a631929662e2a5a0a5fca5e19181215caeefab2a0221b5768e4f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

