### PR TITLE
Fix(ai-hub): update UpdateLeadInfoFromSummary function

### DIFF
--- a/src/frappe/frappe-client.js
+++ b/src/frappe/frappe-client.js
@@ -192,7 +192,8 @@ export default class FrappeClient {
       if (data.exc) throw new Error(data.exc);
       return data.message || data.data || null;
     } catch (e) {
-      throw this.parseErrorMessage(e);
+      const parsed = this.parseErrorMessage(e) || (e && e.message) || text;
+      throw new Error(parsed);
     }
   }
   async executeSQL(sql) {

--- a/src/services/erp/crm/lead/lead.js
+++ b/src/services/erp/crm/lead/lead.js
@@ -26,14 +26,24 @@ export default class LeadService {
   }
 
   async updateLeadInfoFromSummary(data, conversationId) {
-    let res = await this.frappeClient.postRequest("", {
-      cmd: "erpnext.crm.doctype.lead.lead_methods.update_lead_from_summary",
-      data: JSON.stringify({
-        ...data,
-        conversation_id: conversationId
-      })
-    });
-    return { success: true, data: res };
+    try {
+      const res = await this.frappeClient.postRequest("", {
+        cmd: "erpnext.crm.doctype.lead.lead_methods.update_lead_from_summary",
+        data: JSON.stringify({
+          ...data,
+          conversation_id: conversationId
+        })
+      });
+      return { success: true, data: res };
+    } catch (error) {
+      const message = (error && error.message) ? error.message : String(error);
+      console.warn("Failed to update lead info from summary:", error, {
+        error: message,
+        conversationId,
+        data
+      });
+      return { success: false, error: message };
+    }
   }
 
   async findLeadByConversationId(conversationId) {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Enhanced error handling in Frappe client and lead service

- Added try-catch wrapper to `updateLeadInfoFromSummary` function

- Improved error parsing and logging for better debugging


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Frappe Client"] -- "improved error parsing" --> B["Error Handler"]
  C["Lead Service"] -- "wrapped with try-catch" --> D["updateLeadInfoFromSummary"]
  D -- "returns success/error object" --> E["Caller"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>frappe-client.js</strong><dd><code>Improved error parsing in Frappe client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frappe/frappe-client.js

<ul><li>Enhanced error parsing in <code>postProcess</code> method<br> <li> Added fallback error message handling for better error reporting</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/202/files#diff-d95d6972b0eaea78b490901e389c647f07fa025b6b7e17a636b8ee4baf3fb8d4">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lead.js</strong><dd><code>Added error handling to lead update function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/erp/crm/lead/lead.js

<ul><li>Wrapped <code>updateLeadInfoFromSummary</code> function with try-catch block<br> <li> Added error logging with context information<br> <li> Changed return format to include success/error status</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/202/files#diff-78a676ea3f303d19fbb2fac3eb05a628a42ddbad317c13d0b98fb35c9ba5d9ea">+18/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

