### PR TITLE
Fix(erp-assignment-rule): setup limit page length when get user list

### DIFF
--- a/src/services/erp/automation/assigment-rule/assigment-rule.js
+++ b/src/services/erp/automation/assigment-rule/assigment-rule.js
@@ -24,14 +24,24 @@ export default class AssignmentRuleService {
   }
 
   async getAssignedUsers(regions) {
-    const salesPeoplePromises = regions.map(region =>
-      this.frappeClient.getList("Sales Person", {
-        filters: [["sales_region", "=", region], ["assigned_lead", "=", true]],
-        limit_page_length: AssignmentRuleService.ERPNEXT_PAGE_SIZE
-      })
-    );
-    const salesPeopleResults = await Promise.all(salesPeoplePromises);
-    const salesPeople = salesPeopleResults.flat();
+    const salesPeople = [];
+    for (const region of regions) {
+      let limitStart = 0;
+      let hasMore = true;
+      while (hasMore) {
+        const pageResults = await this.frappeClient.getList("Sales Person", {
+          filters: [["sales_region", "=", region], ["assigned_lead", "=", true]],
+          limit_start: limitStart,
+          limit_page_length: AssignmentRuleService.ERPNEXT_PAGE_SIZE
+        });
+        salesPeople.push(...pageResults);
+        if (pageResults.length < AssignmentRuleService.ERPNEXT_PAGE_SIZE) {
+          hasMore = false;
+        } else {
+          limitStart += AssignmentRuleService.ERPNEXT_PAGE_SIZE;
+        }
+      }
+    }
 
     const employeeNames = salesPeople.map((salesPerson) => salesPerson.employee);
     const employees = [];


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add static page size constant to AssignmentRuleService class

- Set limit_page_length parameter when fetching Sales Person list

- Prevent potential data truncation in user list retrieval


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AssignmentRuleService"] -->|"adds ERPNEXT_PAGE_SIZE constant"| B["Static constant = 100"]
  C["getAssignedUsers method"] -->|"applies limit_page_length"| D["frappeClient.getList call"]
  D -->|"uses"| B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>assigment-rule.js</strong><dd><code>Add pagination limit to Sales Person list query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/erp/automation/assigment-rule/assigment-rule.js

<ul><li>Added static constant <code>ERPNEXT_PAGE_SIZE</code> set to 100 for pagination<br> <li> Added <code>limit_page_length</code> parameter to <code>frappeClient.getList()</code> call in <br><code>getAssignedUsers</code> method<br> <li> Ensures Sales Person list retrieval respects page size limit</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/371/files#diff-83fe14dc2f175fd8fef377a15b08ff9c88b9e2a2e7fc0c97c837bd5f8cc70c41">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

