### PR TITLE
fix(misa): remove misa secret binding

### DIFF
--- a/src/services/clients/misa-client.js
+++ b/src/services/clients/misa-client.js
@@ -18,7 +18,7 @@ export default class MisaClient {
 
     const payload = {
       app_id: this.env.MISA_APP_ID,
-      access_code: await this.env.MISA_ACCESS_CODE_SECRET.get(),
+      access_code: this.env.MISA_ACCESS_CODE,
       org_company_code: this.env.MISA_ORG_CODE
     };
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -105,11 +105,6 @@
       "binding": "INVENTORY_CMS_STATIC_TOKEN_SECRET",
       "store_id": "dff6fef7003446178302a7874af64fde",
       "secret_name": "INVENTORY_CMS_STATIC_TOKEN"
-    },
-    {
-      "binding": "MISA_ACCESS_CODE_SECRET",
-      "store_id": "dff6fef7003446178302a7874af64fde",
-      "secret_name": "MISA_ACCESS_CODE"
     }
   ],
   "kv_namespaces": [


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove MISA secret binding from wrangler configuration

- Use plain environment variable instead of secret wrapper

- Simplify access code retrieval in MisaClient


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["wrangler.jsonc<br/>Secret Binding"] -->|removed| B["MISA_ACCESS_CODE_SECRET"]
  C["MisaClient.js<br/>getAccessToken"] -->|changed to| D["MISA_ACCESS_CODE<br/>Plain Variable"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>misa-client.js</strong><dd><code>Remove secret binding from access code retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/clients/misa-client.js

<ul><li>Changed <code>MISA_ACCESS_CODE_SECRET.get()</code> to <code>MISA_ACCESS_CODE</code><br> <li> Removed async secret retrieval call<br> <li> Simplified payload construction in getAccessToken method</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/386/files#diff-fb4c2a818f87c16f17fda10f13a8c8e5d463ba69f7198559304dfaff1ea0de8c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wrangler.jsonc</strong><dd><code>Remove MISA secret binding from configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

wrangler.jsonc

<ul><li>Removed MISA_ACCESS_CODE_SECRET binding configuration<br> <li> Deleted secret store reference for MISA access code<br> <li> Cleaned up secrets array in wrangler configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/386/files#diff-21d9afdd0ffc457d5e1566045b68c0ca0ecc57ea3e5f704ee22164133e940736">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

