### PR TITLE
chore(misa): correcting start date for monring batch

### DIFF
--- a/src/services/payment/misa/voucher-sync-service.js
+++ b/src/services/payment/misa/voucher-sync-service.js
@@ -22,7 +22,7 @@ export default class MisaVoucherSyncService {
    */
   async runMorningBatch() {
     const now = dayjs().utc();
-    const startDate = now.subtract(2, "day").hour(11).minute(0).second(0);
+    const startDate = now.subtract(1, "day").hour(11).minute(0).second(0);
     const endDate = now.hour(1).minute(30).second(0);
     await this._createVouchersForDateRange(startDate.toDate(), endDate.toDate());
   }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Corrects morning batch start date calculation from 2 days to 1 day prior

- Fixes incorrect date range for voucher creation process


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Morning Batch Start Date"] -->|Changed from| B["2 days prior at 11:00"]
  A -->|Changed to| C["1 day prior at 11:00"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>voucher-sync-service.js</strong><dd><code>Correct morning batch start date offset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/payment/misa/voucher-sync-service.js

<ul><li>Modified <code>runMorningBatch()</code> method to correct start date calculation<br> <li> Changed <code>subtract(2, "day")</code> to <code>subtract(1, "day")</code> for proper date range<br> <li> Fixes voucher creation to use correct historical date window</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/387/files#diff-741ddedd88f6745edb6cbb0354365b4a8423b116f987ea9c3b8d41069a01f3ad">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

