### PR TITLE
chore(pancake): gracefully response when internal error

### DIFF
--- a/src/controllers/webhook/pancake/erp/message.js
+++ b/src/controllers/webhook/pancake/erp/message.js
@@ -4,30 +4,26 @@ import { shouldReceiveWebhook } from "controllers/webhook/pancake/erp/utils";
 export default class PancakeERPMessageController {
   static async create(ctx) {
     const data = await ctx.req.json();
-    try {
-      if (data.event_type === "messaging") {
-        const receiveWebhook = shouldReceiveWebhook(data);
+    if (data.event_type === "messaging") {
+      const receiveWebhook = shouldReceiveWebhook(data);
 
-        if (!receiveWebhook) {
-          return ctx.json({ message: "Message Ignored" });
-        }
-
-        await ctx.env["MESSAGE_QUEUE"].send(data);
-
-        const conversationId = data?.data?.conversation?.id;
-
-        const key = `conversation-${conversationId}`;
-        await DebounceService.debounce({
-          env: ctx.env,
-          key: key,
-          data: data,
-          actionType: DebounceActions.SEND_TO_MESSAGE_SUMMARY_QUEUE,
-          delay: 30000
-        });
+      if (!receiveWebhook) {
+        return ctx.json({ message: "Message Ignored" });
       }
-      return ctx.json({ message: "Message Received" });
-    } catch {
-      return ctx.json({ message: "Failed to send message to queue", status: 500 });
+
+      await ctx.env["MESSAGE_QUEUE"].send(data);
+
+      const conversationId = data?.data?.conversation?.id;
+
+      const key = `conversation-${conversationId}`;
+      await DebounceService.debounce({
+        env: ctx.env,
+        key: key,
+        data: data,
+        actionType: DebounceActions.SEND_TO_MESSAGE_SUMMARY_QUEUE,
+        delay: 30000
+      });
     }
+    return ctx.json({ message: "Message Received" });
   }
 }


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Replace HTTPException throw with graceful JSON response

- Remove unused HTTPException import from Hono

- Return proper error status in catch block instead of throwing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Error in message queue"] --> B["Previous: throw HTTPException"]
  A --> C["New: return JSON with status"]
  B --> D["Unhandled exception"]
  C --> E["Graceful error response"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>message.js</strong><dd><code>Replace exception throw with graceful JSON error response</code></dd></summary>
<hr>

src/controllers/webhook/pancake/erp/message.js

<ul><li>Removed unused <code>HTTPException</code> import from Hono<br> <li> Changed error handling in catch block from throwing exception to <br>returning JSON response<br> <li> Error response now includes message and status code in JSON format</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/388/files#diff-23c5e9e5b1c7878aeda0de0f8278b5f696b2c710c7468f7392796d2dad6fee58">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

