### PR TITLE
fix(syncDB): invalid array buffer length

### DIFF
--- a/src/services/erp/contacts/address/utils/address-helppers.js
+++ b/src/services/erp/contacts/address/utils/address-helppers.js
@@ -7,7 +7,7 @@ import { mapAddressesToDatabase } from "src/services/erp/contacts/address/utils/
 import { escapeSqlValue } from "src/services/utils/sql-helpers";
 dayjs.extend(utc);
 
-const CHUNK_SIZE = 100;
+const CHUNK_SIZE = 50;
 
 export async function fetchAddressesFromERP(frappeClient, doctype, fromDate, toDate, pageSize) {
   try {

--- a/src/services/erp/contacts/contact/utils/contact-helppers.js
+++ b/src/services/erp/contacts/contact/utils/contact-helppers.js
@@ -7,7 +7,7 @@ import { mapContactsToDatabase } from "src/services/erp/contacts/contact/utils/c
 import { escapeSqlValue } from "src/services/utils/sql-helpers";
 dayjs.extend(utc);
 
-const CHUNK_SIZE = 100;
+const CHUNK_SIZE = 50;
 
 export async function fetchContactsFromERP(frappeClient, doctype, fromDate, toDate, pageSize) {
   try {

--- a/src/services/erp/crm/lead/utils/lead-helppers.js
+++ b/src/services/erp/crm/lead/utils/lead-helppers.js
@@ -7,7 +7,7 @@ import { mapLeadsToDatabase } from "src/services/erp/crm/lead/utils/lead-mappers
 import { escapeSqlValue } from "src/services/utils/sql-helpers";
 dayjs.extend(utc);
 
-const CHUNK_SIZE = 100;
+const CHUNK_SIZE = 50;
 
 export async function fetchLeadsFromERP(frappeClient, doctype, fromDate, toDate, pageSize) {
   try {

--- a/src/services/erp/selling/customer/utils/customer-helppers.js
+++ b/src/services/erp/selling/customer/utils/customer-helppers.js
@@ -8,7 +8,7 @@ import { fetchChildRecordsFromERP } from "src/services/utils/sql-helpers";
 import { escapeSqlValue } from "src/services/utils/sql-helpers";
 dayjs.extend(utc);
 
-const CHUNK_SIZE = 100;
+const CHUNK_SIZE = 50;
 
 export async function fetchCustomersFromERP(frappeClient, doctype, fromDate, toDate, pageSize) {
   try {

--- a/src/services/erp/selling/sales-order/utils/sales-order-helpers.js
+++ b/src/services/erp/selling/sales-order/utils/sales-order-helpers.js
@@ -9,7 +9,7 @@ import { fetchChildRecordsFromERP } from "src/services/utils/sql-helpers";
 
 dayjs.extend(utc);
 
-const CHUNK_SIZE = 100;
+const CHUNK_SIZE = 30;
 
 export async function fetchSalesOrdersFromERP(frappeClient, doctype, fromDate, toDate, pageSize) {
   try {


### PR DESCRIPTION
### **User description**
Reduce chunk size when upsert records from 100 -> 50.
On local, when I testing with size = 100 there was the warning **Invalid array buffer length**, when changing to 50 the warning went away


___

### **PR Type**
Bug fix


___

### **Description**
- Reduce chunk size from 100 to 50 in address, contact, and lead helpers

- Reduce chunk size from 100 to 30 in sales order helper

- Fixes "Invalid array buffer length" RangeError during record upsert operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Chunk Size 100"] -->|Causes RangeError| B["Invalid array buffer length"]
  C["Reduce to 50/30"] -->|Resolves| D["Successful upsert operations"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>address-helppers.js</strong><dd><code>Reduce address chunk size to 50</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/erp/contacts/address/utils/address-helppers.js

<ul><li>Reduced <code>CHUNK_SIZE</code> constant from 100 to 50<br> <li> Prevents array buffer overflow during address record processing</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/389/files#diff-54f7e046a4cbfab0693cb3f84712eb94007e39cdd6fcea4ee6601a1735516a8e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>contact-helppers.js</strong><dd><code>Reduce contact chunk size to 50</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/erp/contacts/contact/utils/contact-helppers.js

<ul><li>Reduced <code>CHUNK_SIZE</code> constant from 100 to 50<br> <li> Prevents array buffer overflow during contact record processing</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/389/files#diff-a2ef76c296202c2c19a3fcac6b7ff3eee88cc643cb62711064fc8a976932e490">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lead-helppers.js</strong><dd><code>Reduce lead chunk size to 50</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/erp/crm/lead/utils/lead-helppers.js

<ul><li>Reduced <code>CHUNK_SIZE</code> constant from 100 to 50<br> <li> Prevents array buffer overflow during lead record processing</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/389/files#diff-a9b58f45c55b38be4f71014df5a4fa11c00fc277498d463402eca83defefc778">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>customer-helppers.js</strong><dd><code>Reduce customer chunk size to 50</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/erp/selling/customer/utils/customer-helppers.js

<ul><li>Reduced <code>CHUNK_SIZE</code> constant from 100 to 50<br> <li> Prevents array buffer overflow during customer record processing</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/389/files#diff-a94803321342f85819524d4dab3ee54db6378a6c7b76479308d16b9087107135">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sales-order-helpers.js</strong><dd><code>Reduce sales order chunk size to 30</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/erp/selling/sales-order/utils/sales-order-helpers.js

<ul><li>Reduced <code>CHUNK_SIZE</code> constant from 100 to 30<br> <li> More aggressive chunk size reduction for sales order processing<br> <li> Prevents array buffer overflow during sales order record upsert</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/389/files#diff-e5ec9b2e1edbafeae3773538ffdc60f3cb03472dee94f7a8dc344a21a04bb4ca">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

