### PR TITLE
feat(haravan): fix 429 too many request when sync inventory item

### DIFF
--- a/src/services/clients/haravan-client/base-connector.js
+++ b/src/services/clients/haravan-client/base-connector.js
@@ -36,7 +36,14 @@ class BaseConnector {
     const response = await fetch(url.toString(), options);
 
     if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+      const error = new Error(`HTTP error! status: ${response.status}`);
+      error.status = response.status;
+
+      if (response.status === 429) {
+        error.retryAfter = response.headers.get("retry-after");
+      }
+
+      throw error;
     }
 
     return response.json();


### PR DESCRIPTION
## Changes
Respect Haravan's API [rate limiting](https://docs.haravan.com/docs/omni-apis/api-call-limit/#retry-after-header) to fix 429 errors:

- 500ms delay between requests (stays under 4 req/sec limit)
- On 429 error, sleep for `Retry-After` seconds (max 3s) and retry
  - Aborts sync if wait >3s (will retry on next scheduled run)
  - Skips proactive delay after 429 to avoid double-sleeping

#### Issue: #450