### PR TITLE
feat(misa): added 30 minute cronjob for misa voucher creation

### DIFF
--- a/src/services/schedule-handler.js
+++ b/src/services/schedule-handler.js
@@ -37,6 +37,7 @@ export default {
       await ERP.Contacts.AddressService.cronSyncAddressesToDatabase(env);
       await Ecommerce.ProductService.refreshMaterializedViews(env);
       await DatabaseOperations.MaterializedViewService.refresh30Minutes(env);
+      await new Payment.MisaVoucherSyncService(env).runThirtyMinutesBatch();
       break;
     case "0 */3 * * *": // At every 3rd hour
       await InventoryCMS.InventoryCheckSheetService.syncInventoryCheckSheetToDatabase(env);


### PR DESCRIPTION
### Changes
- Added a 30-minute cron to create MISA vouchers
  - Sometimes the accounting team needs vouchers ASAP, but our current cron schedule (08:30, 13:30, 18:00) is too infrequent when transactions come in on the same day.
  - This 30-minute cron will be skipped if it happens to run at the same time as the main cron above.

#### Ticket: [Link](https://applink.larksuite.com/client/todo/detail?guid=3049b95b-3f9e-4068-9351-6662d6561a87&suite_entity_num=t116626)