### PR TITLE
fix: cast to int for bigint

### DIFF
--- a/src/services/payment/qr_payment/map-qr-with-bank-transaction-service.js
+++ b/src/services/payment/qr_payment/map-qr-with-bank-transaction-service.js
@@ -58,8 +58,8 @@ export default class MapQRWithBankTransactionService {
       }));
     }
 
-    const sepayTransactionAmount = parseInt(sepayTransaction.amount_in);
-    if (Math.abs(sepayTransactionAmount - Number(qrPayment.transfer_amount)) > 1000) {
+    const sepayTransactionAmount = parseFloat(sepayTransaction.amount_in);
+    if (Math.abs(sepayTransactionAmount - parseFloat(qrPayment.transfer_amount)) > 1000) {
       throw new Error(JSON.stringify({
         error_msg: `Sepay transaction with id ${sepayTransactionId} amount is not equal to QR's amount`,
         error_code: MapQRWithBankTransactionService.AMOUNT_MISMATCH
@@ -102,7 +102,7 @@ export default class MapQRWithBankTransactionService {
     const createdOrderTransaction = await haravanService.orderTransaction.createTransaction(
       qrPayment.haravan_order_id,
       {
-        amount: Number(qrPayment.transfer_amount),
+        amount: parseFloat(qrPayment.transfer_amount),
         kind: "capture",
         gateway: "Chuyển khoản ngân hàng (tự động xác nhận giao dịch)"
       }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Convert `qrPayment.transfer_amount` to number type in two locations

- Ensures proper numeric comparison and API parameter handling

- Prevents type coercion issues with bigint or string values


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["qrPayment.transfer_amount<br/>string/bigint"] -- "Number() conversion" --> B["Numeric value"]
  B -- "Amount comparison" --> C["Sepay validation"]
  B -- "Haravan API call" --> D["Transaction creation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>map-qr-with-bank-transaction-service.js</strong><dd><code>Add Number() type conversion for transfer_amount</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/payment/qr_payment/map-qr-with-bank-transaction-service.js

<ul><li>Wrapped <code>qrPayment.transfer_amount</code> with <code>Number()</code> in amount comparison <br>logic (line 64)<br> <li> Wrapped <code>qrPayment.transfer_amount</code> with <code>Number()</code> in Haravan API <br>transaction creation (line 105)<br> <li> Ensures consistent numeric type handling across payment validation and <br>API calls</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/467/files#diff-250d881904396bdc7d0efca97c79fd88c90a44564a4ca69e8e9993a8ffadc55d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

