### PR TITLE
feat(lark): add axios client creation method for API calls

### DIFF
--- a/src/services/larksuite/lark.js
+++ b/src/services/larksuite/lark.js
@@ -1,5 +1,6 @@
 import * as lark from "@larksuiteoapi/node-sdk";
 import { createFetchAdapter } from "@haverstack/axios-fetch-adapter";
+import axios from "axios";
 const fetchAdapter = createFetchAdapter();
 
 export default class LarksuiteService {
@@ -23,6 +24,17 @@ export default class LarksuiteService {
       domain: larkApiEndpoint
     });
     client.httpInstance.defaults.adapter = fetchAdapter;
+    return client;
+  }
+
+  static async createAxiosClient(env) {
+    const token = await this.getTenantAccessToken(env);
+    const client = axios.create({
+      baseURL: env.LARK_API_ENDPOINT,
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
     return client;
   }
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add new `createAxiosClient` method for direct API calls

- Method retrieves tenant access token and configures axios client

- Enables alternative HTTP client option alongside existing Lark SDK


___

### Diagram Walkthrough


```mermaid
flowchart LR
  env["Environment Config"] -- "getTenantAccessToken" --> token["Tenant Access Token"]
  token -- "axios.create" --> axiosClient["Axios Client Instance"]
  axiosClient -- "baseURL + Authorization" --> apiReady["Ready for API Calls"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lark.js</strong><dd><code>Add axios client creation method with token auth</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/larksuite/lark.js

<ul><li>Added <code>axios</code> import for HTTP client creation<br> <li> Implemented new <code>createAxiosClient</code> static method that retrieves tenant <br>access token and creates configured axios instance<br> <li> Axios client configured with base URL and Bearer token authorization <br>header</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/478/files#diff-482ec143eb5d528fdafab0b3c69fc1b8bcec6455f7cae9ad52bea8e04e93d79d">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

