### PR TITLE
fix: get qty_available from inventory_advance

### DIFF
--- a/src/services/haravan/products/product-variant/product-variant-service.js
+++ b/src/services/haravan/products/product-variant/product-variant-service.js
@@ -15,7 +15,7 @@ export default class ProductVariantService {
     for (const variant of variants) {
       const qty = variant?.inventory_advance?.qty_available ?? 0;
 
-      if (qty && qty > 0) {
+      if (qty > 0) {
         const diamond = await workplaceClient.diamonds.findOne({
           where: `(product_id,eq,${product.id})~and(variant_id,eq,${variant.id})~and(is_incoming,is,true)`
         });


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Extract `qty_available` from nested `inventory_advance` object

- Add null check for `qty` before comparison


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["variant.qty_available"] -->|Before| B["Direct access"]
  C["variant.inventory_advance.qty_available"] -->|After| D["Nested object access"]
  D --> E["Add null check"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>product-variant-service.js</strong><dd><code>Fix qty_available extraction and add null safety</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/haravan/products/product-variant/product-variant-service.js

<ul><li>Changed <code>qty_available</code> access from direct property to nested <br><code>inventory_advance</code> object<br> <li> Updated condition to include null check for <code>qty</code> before numeric <br>comparison<br> <li> Prevents potential errors when <code>qty</code> is falsy or undefined</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/482/files#diff-de5d28f0af436ad071202cbe15ea7c18734085f0cdd557bab1b521e34358714d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

