### PR TITLE
feat(misa): skipping dictionary save  function from misa callback

### DIFF
--- a/src/controllers/webhook/misa/callback/callback-results-controller.js
+++ b/src/controllers/webhook/misa/callback/callback-results-controller.js
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/cloudflare";
+import Misa from "services/misa";
 
 const ONE_MINUTE_DELAY = 60;
 
@@ -6,7 +7,10 @@ export default class CallbackResultsController {
   static async create(ctx) {
     try {
       const payload = await ctx.req.json();
-      await ctx.env["MISA_QUEUE"].send(payload, { delaySeconds: ONE_MINUTE_DELAY });
+      if (payload.data_type === Misa.Constants.CALLBACK_TYPE.SAVE_FUNCTION) {
+        await ctx.env["MISA_QUEUE"].send(payload, { delaySeconds: ONE_MINUTE_DELAY });
+      }
+
       return ctx.json({ message: "Message receive", status: 200 });
     } catch (e) {
       Sentry.captureException(e);


### PR DESCRIPTION
### **User description**
#### Changes
- Fix : https://github.com/jemmia-diamond/fn/issues/489


___

### **PR Type**
Bug fix


___

### **Description**
- Skip processing SAVE_DICTIONARY callback type in webhook

- Prevent queue overflow from inventory sync operations

- Add SAVE_DICTIONARY constant to callback types


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Webhook Callback Received"] --> B{"Check callback type"}
  B -->|SAVE_DICTIONARY| C["Return early without queuing"]
  B -->|Other types| D["Queue message with delay"]
  C --> E["Prevent queue overflow"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>callback-results-controller.js</strong><dd><code>Filter SAVE_DICTIONARY callbacks from queue processing</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/controllers/webhook/misa/callback/callback-results-controller.js

<ul><li>Import Misa service to access callback type constants<br> <li> Add early return check for SAVE_DICTIONARY callback type<br> <li> Skip queue processing for dictionary save operations<br> <li> Prevent queue overflow by filtering specific callback types</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/490/files#diff-192b5d44a3c95de59347be231c19331b405845944e316466fc578a3ba9fb5432">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>constant.js</strong><dd><code>Add SAVE_DICTIONARY callback type constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/misa/constant.js

<ul><li>Add SAVE_DICTIONARY constant with value 7 to CALLBACK_TYPE<br> <li> Extend callback type definitions for filtering logic</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/490/files#diff-c33d95b1246cab7592186d65ccd6eb1b4b49fc8b0636362917fb2a93074d52bf">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

