### PR TITLE
fix: add null check for item.sku when filtering order line items

### DIFF
--- a/src/services/haravan/orders/order-service/order-service.js
+++ b/src/services/haravan/orders/order-service/order-service.js
@@ -22,7 +22,7 @@ export default class OrderService {
 
   async invalidOrderNotification(order) {
     const jewelrySKULength = 21;
-    const jewelryVariants = order.line_items.filter(item => item.sku.toString().length === jewelrySKULength);
+    const jewelryVariants = order.line_items.filter(item => item.sku && item.sku.toString().length === jewelrySKULength);
     const negativeOrderedVariants = [];
     for (const jewelryVariant of jewelryVariants) {
       const productData = (await this.hrvClient.products.product.getProduct(jewelryVariant.product_id)).data.product;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add null check for `item.sku` before calling toString() method

- Prevents potential TypeError when filtering order line items

- Ensures robustness when processing orders with missing SKU values


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Order line_items filter"] -->|Before: No null check| B["Potential TypeError"]
  A -->|After: Added null check| C["Safe toString() call"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>order-service.js</strong><dd><code>Add null safety check for SKU filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/haravan/orders/order-service/order-service.js

<ul><li>Added null check condition <code>item.sku &&</code> before calling <code>toString()</code> <br>method<br> <li> Prevents TypeError when <code>item.sku</code> is null or undefined<br> <li> Maintains existing filter logic for valid SKU values</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/517/files#diff-c719c4b10c89c217e1289c4be99db62fe01898f9a93780508da8a1913f343f5a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

