### PR TITLE
feat(sales-order): add fulfillment complete date

### DIFF
--- a/src/services/erp/selling/sales-order/sales-order.js
+++ b/src/services/erp/selling/sales-order/sales-order.js
@@ -110,6 +110,7 @@ export default class SalesOrderService {
       skip_delivery_note: 1,
       financial_status: this.financialStatusMapper[haravanOrderData.financial_status],
       fulfillment_status: this.fulfillmentStatusMapper[haravanOrderData.fulfillment_status],
+      fulfillment_completion_date: haravanOrderData.fulfillments.length && haravanOrderData.fulfillments[0].delivered_date ? dayjs(haravanOrderData.fulfillments[0].delivered_date).format("YYYY-MM-DD HH:mm:ss") : null,
       cancelled_status: this.cancelledStatusMapper[haravanOrderData.cancelled_status],
       carrier_status: haravanOrderData.fulfillments.length ? this.carrierStatusMapper[haravanOrderData.fulfillments[0].carrier_status_code] : this.carrierStatusMapper.notdelivered,
       transaction_date: dayjs(haravanOrderData.created_at).add(7, "hour").format("YYYY-MM-DD"),


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add fulfillment completion date field to sales order mapping

- Extract delivered date from fulfillments array with fallback

- Format date as YYYY-MM-DD HH:mm:ss timestamp string


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Haravan Order Data"] -->|"Extract fulfillments"| B["Fulfillments Array"]
  B -->|"Get delivered_date"| C["Delivered Date"]
  C -->|"Format with dayjs"| D["fulfillment_completion_date"]
  B -->|"Empty or null"| E["null value"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sales-order.js</strong><dd><code>Add fulfillment completion date field mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/erp/selling/sales-order/sales-order.js

<ul><li>Added <code>fulfillment_completion_date</code> field to sales order mapping<br> <li> Extracts delivered date from first fulfillment in array<br> <li> Formats date using dayjs to YYYY-MM-DD HH:mm:ss format<br> <li> Returns null if fulfillments array is empty or delivered_date is <br>missing</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/523/files#diff-4c0efcc4b18a631929662e2a5a0a5fca5e19181215caeefab2a0221b5768e4f6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

