### PR TITLE
feat(payment-entry): prevent PE status updated to sucess if sales person just mapping order

### DIFF
--- a/src/services/payment/manual-pay/payment.js
+++ b/src/services/payment/manual-pay/payment.js
@@ -169,7 +169,7 @@ export default class ManualPaymentService {
         return null;
       }
 
-      if (paymentBeforeUpdate.transfer_status === "Xác nhận") {
+      if (paymentBeforeUpdate.transfer_status === "Xác nhận" && !data.payment_entry_name) {
         const updateData = { ...data };
 
         delete updateData.transfer_status;
@@ -197,7 +197,7 @@ export default class ManualPaymentService {
       delete dataForFirstUpdate.transfer_status;
 
       const isOrderLater = dataForFirstUpdate.haravan_order_name === "Đơn hàng cọc";
-      if (!isOrderLater) {
+      if (!isOrderLater && !data.payment_entry_name) {
         const orderExists = await this.db.order.findUnique({
           where: { id: dataForFirstUpdate.haravan_order_id }
         });
@@ -206,7 +206,7 @@ export default class ManualPaymentService {
         }
       }
 
-      if (isOrderLater) {
+      if (isOrderLater && !data.payment_entry_name) {
         delete dataForFirstUpdate.haravan_order_id;
       }
 


### PR DESCRIPTION
#### Changes
- Fix [Sentry](https://jemmia.sentry.io/issues/7110663483/?project=4509356967002112&query=!is%3Aunresolved%20assigned%3Ame&referrer=issue-stream)
- Not update Payment Entry (PE) status and transfer status if sales just mapping order
  - We only update status if Accountant verify (PE)