### PR TITLE
feat(harvan): apply simple haravan retry logic

### DIFF
--- a/src/services/clients/haravan-client/base-connector.js
+++ b/src/services/clients/haravan-client/base-connector.js
@@ -1,13 +1,20 @@
 import axios from "axios";
 import axiosRetry from "axios-retry";
 
+const RETRY_CONFIG = {
+  retries: 2,
+  retryDelay: axiosRetry.exponentialDelay,
+  shouldResetTimeout: true,
+  retryCondition: (error) =>
+    axiosRetry.isNetworkOrIdempotentRequestError(error) ||
+    error.response?.status >= 500
+};
+
 class BaseConnector {
   constructor(accessToken = null) {
     this.accessToken = accessToken;
     this.baseUrl = "https://apis.haravan.com/com";
     this.timeout = 30000;
-    this.maxRetries = 2;
-    this.retryDelay = 1000;
   }
 
   getHeaders() {
@@ -23,12 +30,7 @@ class BaseConnector {
       timeout: this.timeout,
       headers: this.getHeaders()
     });
-
-    axiosRetry(client, {
-      retries: this.maxRetries,
-      retryDelay: () => this.retryDelay,
-      shouldResetTimeout: true
-    });
+    axiosRetry(client, RETRY_CONFIG);
 
     return client;
   }


### PR DESCRIPTION
#### Sentry Issues
- Sync HRV Order - [Link](https://jemmia.sentry.io/issues/7123631153/events/42227c8399464ca0aed01fae99ffb419/)
- SalesOrder Notification - [Link](https://jemmia.sentry.io/issues/7076278739/events/3f96dd4d53404ab59a9c2afda55f0272/)
- Misa inventory sync - [Link](https://jemmia.sentry.io/issues/7064374168/events/abf0231b45b4460ab4edd2c3414ec2a0/)
#### Symptom
- Even though, the timeout limit by our end is 30 second, haravan still not response to our server and we are missing retry logic

#### Changes
- Applied simple retry logic for the Haravan client using the axios-retry package
  - this does not eliminate the current timeout issue, but it helps mitigate it