### PR TITLE
fix(misa): using correct field

### DIFF
--- a/src/services/misa/customer/customer-creator.js
+++ b/src/services/misa/customer/customer-creator.js
@@ -102,7 +102,7 @@ export default class CustomerCreator {
           email: contact_email,
           address,
           haravan_created_at: customerData.created_at ? new Date(customerData.created_at) : null,
-          synced_at: new Date()
+          last_synced_at: new Date()
         }
       });
     }


### PR DESCRIPTION
### **User description**
- hotfix [Sentry](https://jemmia.sentry.io/issues/7164839945/?alert_rule_id=16008017&alert_timestamp=1767593643199&alert_type=email&environment=production&notification_uuid=ee876d65-df5a-4775-91d2-60bd7fe6964e&project=4509356967002112&referrer=alert_email)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix incorrect field name in customer sync operation

- Changed `synced_at` to `last_synced_at` for consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Customer Creator"] -- "Update field name" --> B["synced_at → last_synced_at"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>customer-creator.js</strong><dd><code>Correct field name in customer sync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/misa/customer/customer-creator.js

<ul><li>Changed field name from <code>synced_at</code> to <code>last_synced_at</code> in customer object <br>creation<br> <li> Ensures correct field naming convention for tracking last sync <br>timestamp</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/601/files#diff-5fe9e8051fc0e9205c0aac1162630cac7d3731a0b6e63c5fefcdd872118a7705">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

