### PR TITLE
fix: ignore non-sepay transaction

### DIFF
--- a/src/services/erp/accounting/bank-transaction/bank-transaction.js
+++ b/src/services/erp/accounting/bank-transaction/bank-transaction.js
@@ -48,7 +48,8 @@ export default class BankTransactionService {
 
       const filters = [
         ["creation", ">=", oneDayAgoUTC],
-        ["creation", "<=", nowUTC]
+        ["creation", "<=", nowUTC],
+        ["transaction_type", "=", "SePay"]
       ];
 
       EXCLUDED_TRANSACTION_PATTERNS.forEach(pattern => {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add filter to only process SePay transactions

- Exclude non-SePay transaction types from bank transaction sync


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Bank Transaction Query"] -- "Add filter" --> B["transaction_type = SePay"]
  B -- "Result" --> C["Only SePay transactions processed"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bank-transaction.js</strong><dd><code>Add SePay transaction type filter to query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/erp/accounting/bank-transaction/bank-transaction.js

<ul><li>Added transaction type filter to query conditions<br> <li> Filter restricts results to only SePay transactions<br> <li> Prevents non-SePay transactions from being processed</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/604/files#diff-fed5e25f8b95c56e2957d53268ce4730063a7d81e670f3bd93f0fd76ac501239">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

