### PR TITLE
fix(sepay): update query condition

### DIFF
--- a/src/services/erp/accounting/sepay-transaction/sepay-transaction.js
+++ b/src/services/erp/accounting/sepay-transaction/sepay-transaction.js
@@ -44,11 +44,7 @@ export default class SepayTransactionService {
 
     const isOrderLater = orderNumber === "ORDERLATER";
 
-    const qr = await this.findQrRecord({
-      orderNumber,
-      orderDesc,
-      transferAmount
-    });
+    const qr = await this.findQrRecord({ orderDesc, transferAmount });
 
     if (!qr) throw new Error("QR code not found");
 
@@ -355,30 +351,15 @@ export default class SepayTransactionService {
     return upsertedTransaction;
   }
 
-  async findQrRecord({ orderNumber, orderDesc, transferAmount }) {
-    let qr = await this.db.qrPaymentTransaction.findFirst({
+  async findQrRecord({ orderDesc, transferAmount }) {
+    return this.db.qrPaymentTransaction.findFirst({
       where: {
-        haravan_order_number: orderNumber,
         transfer_note: orderDesc,
         transfer_amount: transferAmount,
         transfer_status: "pending",
         is_deleted: false
       }
     });
-
-    // If not found, search by transfer_note only (for orders that have been mapped)
-    if (!qr) {
-      qr = await this.db.qrPaymentTransaction.findFirst({
-        where: {
-          transfer_note: orderDesc,
-          transfer_amount: transferAmount,
-          transfer_status: "pending",
-          is_deleted: false
-        }
-      });
-    }
-
-    return qr;
   }
 
   async enqueueMisaBackgroundJob(qrRecord) {


### PR DESCRIPTION
### **User description**
#### Changes
- Added fallback search for QR records
  - Applies when sales create a “Đơn cọc” and later decide to map the order, but the customer has not transferred the money yet


___

### **PR Type**
Bug fix


___

### **Description**
- Added fallback search mechanism for QR payment records

- Searches by transfer note and amount when initial query fails

- Handles cases where sales map orders before customer transfers money

- Improves transaction matching for mapped "Đơn cọc" orders


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["findQrRecord called"] --> B["Search by order number<br/>transfer note & amount"]
  B --> C{QR record<br/>found?}
  C -->|Yes| D["Return QR record"]
  C -->|No| E["Fallback: Search by<br/>transfer note & amount only"]
  E --> F["Return QR record<br/>or null"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sepay-transaction.js</strong><dd><code>Add fallback QR record search logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/erp/accounting/sepay-transaction/sepay-transaction.js

<ul><li>Modified <code>findQrRecord</code> method to store initial query result in variable<br> <li> Added fallback search logic that queries by transfer note and amount <br>only<br> <li> Fallback search executes when initial search returns no results<br> <li> Returns the found QR record or null if neither search succeeds</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/606/files#diff-d38053b998eecea9d3d9c291d696c5f96f21e29302f09bd812013f74f0fa7091">+15/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

