### PR TITLE
chore(uptimerobot): make uptime reporting run first

### DIFF
--- a/src/services/reporting/uptime/uptime-report-sync.js
+++ b/src/services/reporting/uptime/uptime-report-sync.js
@@ -3,6 +3,7 @@ import Database from "services/database";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import isSameOrBefore from "dayjs/plugin/isSameOrBefore";
+import * as Sentry from "@sentry/cloudflare";
 
 dayjs.extend(utc);
 dayjs.extend(isSameOrBefore);
@@ -94,6 +95,11 @@ export default class UptimeReportSyncService {
   }
 
   async dailySync() {
-    await this.syncUptimeReports(dayjs().utc());
+    try {
+      await this.syncUptimeReports(dayjs().utc());
+    } catch (error) {
+      Sentry.captureException(error);
+      return;
+    }
   }
 }

--- a/src/services/schedule-handler.js
+++ b/src/services/schedule-handler.js
@@ -55,6 +55,7 @@ export default {
       await DatabaseOperations.MaterializedViewService.refresh3Hours(env);
       break;
     case "0 17 * * *": // 00:00
+      await new Reporting.UptimeReportSyncService(env).dailySync();
       await Larksuite.Contact.UserService.syncUsersToDatabase(env);
       await ERP.Core.UserService.syncLarkIds(env);
       await ERP.Core.UserService.syncUsersToDatabase(env);
@@ -62,7 +63,6 @@ export default {
       await ERP.Selling.SalesPersonService.syncSalesPersonToDatabase(env);
       await Larksuite.Docs.Base.RecordService.syncRecordsToDatabase(env);
       await new Ecommerce.DiamondCollectService(env).syncDiamondsToCollects();
-      await new Reporting.UptimeReportSyncService(env).dailySync();
       break;
     case "30 0 * * *": // 07:30
       await ERP.CRM.LeadDemandService.syncLeadDemandToDatabase(env);


### PR DESCRIPTION
### **User description**
#### Changes
- Run reporting service first in cron
- Isolate reporting errors with Sentry to avoid impacting subsequent services


___

### **PR Type**
Enhancement


___

### **Description**
- Add Sentry error handling to uptime reporting service

- Move uptime report sync to run first in daily cron

- Gracefully handle errors without impacting subsequent services


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Schedule Handler"] -->|"Executes first"| B["Uptime Report Sync"]
  B -->|"Wrapped with try-catch"| C["Sentry Error Capture"]
  C -->|"Continues on error"| D["Subsequent Services"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>uptime-report-sync.js</strong><dd><code>Add Sentry error handling to sync method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/reporting/uptime/uptime-report-sync.js

<ul><li>Import Sentry error tracking library<br> <li> Wrap <code>dailySync()</code> method with try-catch block<br> <li> Capture exceptions to Sentry and gracefully return on error</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/631/files#diff-bd0d4b320873efed371f3e7a08bbe3a9838c8d610113464369113b38968f8c6c">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schedule-handler.js</strong><dd><code>Reorder uptime sync to run first in cron</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/schedule-handler.js

<ul><li>Move uptime report sync execution to first position in daily cron<br> <li> Reorder from last to first in the "0 17 * * *" schedule case</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/fn/pull/631/files#diff-eeb908f64f9bbcdb57da3ace0899b06c05c39a66be4821d3057797de320bfa74">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

