### PR TITLE
fix: skipping shared payments for subsequent splits

### DIFF
--- a/src/services/erp/selling/sales-order/utils/sales-order-helpers.js
+++ b/src/services/erp/selling/sales-order/utils/sales-order-helpers.js
@@ -202,3 +202,8 @@ export async function getAllRelatedPaymentEntries(frappeClient, relatedOrderName
   });
   return paymentEntries;
 }
+
+export function shouldSkipSharedPayment(referenceName, currentOrderName, isSplitOrder, isFirstSplitOrder) {
+  const isShared = referenceName !== currentOrderName;
+  return isShared && isSplitOrder && !isFirstSplitOrder;
+}


### PR DESCRIPTION
- fix if 2 split order of group are reordered from the same order => need to skip one