### PR TITLE
fix(haravan): bump location and variants chunk and reduce delay time

### DIFF
--- a/src/services/haravan/warehouse-inventories/database-sync-service.js
+++ b/src/services/haravan/warehouse-inventories/database-sync-service.js
@@ -7,11 +7,11 @@ import { sleep } from "services/utils/sleep.js";
 
 dayjs.extend(utc);
 
-const VARIANT_CHUNK_SIZE = 20;
-const LOCATION_CHUNK_SIZE = 5;
+const VARIANT_CHUNK_SIZE = 50;
+const LOCATION_CHUNK_SIZE = 20;
 
 export default class DatabaseSyncService {
-  static RATE_LIMIT_DELAY_MS = 500;
+  static RATE_LIMIT_DELAY_MS = 100;
   static MAX_RETRY_AFTER_SECONDS = 3;
   static DEFAULT_KV_KEY = "haravan_warehouse_inventory_sync:last_date";
 


### PR DESCRIPTION
#### Changes
- **Bump** the chunk Location + variant chunk size and **reduce** the delay time


Issue: 5 minute cron schedule got cpu exceed because now walltime is exceed 15minute ( 899k ms)
<img width="884" height="736" alt="image" src="https://github.com/user-attachments/assets/3a738302-050e-416b-9a25-52c715e907da" />



Before change
- Product size: 129 records
- 255 haravan API request  + 125s ( delay rate limit)

After
- Product size: 141 records
- 42 haravan API request  + 4.2s ( delay rate limit)