### PR TITLE
fix(payment-entry): handled when user updated bank

### DIFF
--- a/src/services/erp/accounting/payment-entry/payment-entry.js
+++ b/src/services/erp/accounting/payment-entry/payment-entry.js
@@ -430,7 +430,8 @@ export default class PaymentEntryService {
     }
 
     if ((parseFloat(paymentEntry.paid_amount) !== parseFloat(updateQr.transfer_amount))
-      || (paymentEntry.bank_details.bank_code !== updateQr.bank_code)) {
+      || (paymentEntry.bank_details.bank_code !== updateQr.bank_code)
+      || (paymentEntry.bank_account_no !== updateQr.bank_account_number)) {
       updateQr = await this._updateQRAmount(qrPaymentId, paymentEntry, updateQr);
     }
 


### PR DESCRIPTION
#### Changes
- issue: Bank account number not updated when user updates bank
- root cause: Only checked Payment Entry's paid_amount (transfer_amount) or bank short_code changes, missing validation for bank account number -> even if user changing bank account within the same bank brand, the bank account in Database not updated

Task: [Link](https://github.com/jemmia-diamond/fn/pull/882)