### PR TITLE
fix(sales-order-item): return null if diamond policy is null

### DIFF
--- a/src/services/erp/selling/sales-order-item/sales-order-item.js
+++ b/src/services/erp/selling/sales-order-item/sales-order-item.js
@@ -98,6 +98,8 @@ export default class SalesOrderItemService {
   }
 
   _parseRule(rule) {
+    if (rule == null) return null;
+
     const parts = rule?.split(":");
     if (parts?.length < 3) return null;
 


### PR DESCRIPTION
#### Changes
- Return null if diamond policy from noco is null

<img width="714" height="216" alt="img_v3_02110_3ab6f436-35c4-4e38-b25f-fabfb600aehu" src="https://github.com/user-attachments/assets/97a6ab1e-c8d0-4d22-8127-ad069654c256" />


sentry: [Link](https://jemmia.sentry.io/issues/7432463867/?project=4509356967002112&query=is%3Aunresolved&referrer=issue-stream)
