### PR TITLE
feat(article-sync): optimize image caching, sync timing, and article matching

### DIFF
--- a/src/services/haravan/articles/article-sync-service.js
+++ b/src/services/haravan/articles/article-sync-service.js
@@ -97,16 +97,16 @@ export default class ArticleSyncService {
     return all;
   }
 
-  async checkBlogPair(haravanClient, viBlogId, enBlogId, dateRange = null) {
+  async checkBlogPair(haravanClient, viBlogId, enBlogId, viDateRange = null, enDateRange = null) {
     let viArticles = await this.fetchAllArticles(
       haravanClient,
       viBlogId,
-      dateRange
+      viDateRange
     );
     let enArticles = await this.fetchAllArticles(
       haravanClient,
       enBlogId,
-      dateRange
+      enDateRange
     );
 
     viArticles = viArticles.filter(
@@ -193,13 +193,15 @@ export default class ArticleSyncService {
       const imageService = new ImageTranslationService();
 
       const now = new Date();
-      const yesterday = new Date(now);
-      yesterday.setDate(yesterday.getDate() - 1);
-      yesterday.setHours(0, 0, 0, 0);
+      const endTime = new Date(now);
+      endTime.setHours(21, 0, 0, 0);
+
+      const startTime = new Date(endTime);
+      startTime.setDate(startTime.getDate() - 1);
 
       const dateRange = {
-        min: yesterday.toISOString(),
-        max: now.toISOString()
+        min: startTime.toISOString(),
+        max: endTime.toISOString()
       };
 
       for (const viId of Object.keys(ArticleSyncService.BLOG_ID_MAP)) {
@@ -207,7 +209,7 @@ export default class ArticleSyncService {
 
         try {
           const { matchedPairs, missingArticles, orphanEnArticles } =
-            await this.checkBlogPair(haravanClient, viId, enId, dateRange);
+            await this.checkBlogPair(haravanClient, viId, enId, dateRange, null);
 
           for (const pair of matchedPairs) {
             try {

--- a/src/services/haravan/articles/article-sync-service.js
+++ b/src/services/haravan/articles/article-sync-service.js
@@ -4,6 +4,7 @@ import HaravanSyncHelper from "services/haravan/utils/sync-haravan-helper";
 import { getOpenAICompatibleModel } from "services/utils/llm-helper.js";
 import ImageTranslationService from "services/media/image-translation-service.js";
 import { retryQuery } from "services/utils/retry-utils";
+import { sleep } from "services/utils/sleep.js";
 import * as Sentry from "@sentry/cloudflare";
 import { TRANSLATION_PROMPTS, AI_MODELS } from "src/constants/ai-proxy";
 
@@ -12,10 +13,6 @@ export default class ArticleSyncService {
     FETCH_LIMIT: 50,
     SYNC_THRESHOLD_MS: 600000,
     IMAGE_BATCH_SIZE: 5,
-    IMAGE_MAX_RETRIES: 3,
-    IMAGE_RETRY_DELAY: 2000,
-    ARTICLE_MAX_RETRIES: 3,
-    ARTICLE_RETRY_DELAY: 2000,
     API_REQUEST_DELAY: 200
   };
 
@@ -90,7 +87,7 @@ export default class ArticleSyncService {
       try {
         const data = await retryQuery(async () => {
           return haravanClient.article.getArticles(blogId, params);
-        }, ArticleSyncService.CONFIG.ARTICLE_MAX_RETRIES, ArticleSyncService.CONFIG.ARTICLE_RETRY_DELAY);
+        });
 
         const articles = data.articles || [];
         all = all.concat(articles);
@@ -177,7 +174,7 @@ export default class ArticleSyncService {
     return retryQuery(async () => {
       const newUrl = await imageService.translateImage(fullSrc, this.env);
       return { src, newUrl: typeof newUrl === "string" ? newUrl : fullSrc, success: true };
-    }, ArticleSyncService.CONFIG.IMAGE_MAX_RETRIES, ArticleSyncService.CONFIG.IMAGE_RETRY_DELAY).catch(error => {
+    }).catch(error => {
       Sentry.captureException(error, {
         extra: { src, action: "translateImageWithRetry" }
       });
@@ -220,10 +217,6 @@ export default class ArticleSyncService {
 
     const result = await this.translateImageWithRetry(fullSrc, imageService);
     return result.success ? result.newUrl : fullSrc;
-  }
-
-  async sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
   }
 
   async sync() {
@@ -276,7 +269,7 @@ export default class ArticleSyncService {
                   author: pair.vi.author,
                   image: featuredImage ? { src: featuredImage } : null
                 });
-                await this.sleep(ArticleSyncService.CONFIG.API_REQUEST_DELAY);
+                await sleep(ArticleSyncService.CONFIG.API_REQUEST_DELAY);
               }
             } catch (error) {
               Sentry.captureException(error, {
@@ -294,7 +287,7 @@ export default class ArticleSyncService {
           for (const orphan of orphanEnArticles) {
             try {
               await haravanClient.article.deleteArticle(enId, orphan.id);
-              await this.sleep(ArticleSyncService.CONFIG.API_REQUEST_DELAY);
+              await sleep(ArticleSyncService.CONFIG.API_REQUEST_DELAY);
             } catch (error) {
               Sentry.captureException(error, {
                 extra: {
@@ -324,7 +317,7 @@ export default class ArticleSyncService {
                 published_at: vi.published_at,
                 image: featuredImage ? { src: featuredImage } : null
               });
-              await this.sleep(ArticleSyncService.CONFIG.API_REQUEST_DELAY);
+              await sleep(ArticleSyncService.CONFIG.API_REQUEST_DELAY);
             } catch (error) {
               Sentry.captureException(error, {
                 extra: {

--- a/src/services/haravan/articles/article-sync-service.js
+++ b/src/services/haravan/articles/article-sync-service.js
@@ -9,8 +9,14 @@ import { TRANSLATION_PROMPTS, AI_MODELS } from "src/constants/ai-proxy";
 
 export default class ArticleSyncService {
   static CONFIG = {
-    FETCH_LIMIT: 50, // Articles per page
-    SYNC_THRESHOLD_MS: 600000 // 10 min - VI must be newer than EN by this to trigger sync
+    FETCH_LIMIT: 50,
+    SYNC_THRESHOLD_MS: 600000,
+    IMAGE_BATCH_SIZE: 5,
+    IMAGE_MAX_RETRIES: 3,
+    IMAGE_RETRY_DELAY: 2000,
+    ARTICLE_MAX_RETRIES: 3,
+    ARTICLE_RETRY_DELAY: 2000,
+    API_REQUEST_DELAY: 200
   };
 
   static BLOG_ID_MAP = {
@@ -82,7 +88,10 @@ export default class ArticleSyncService {
 
     while (hasMore) {
       try {
-        const data = await haravanClient.article.getArticles(blogId, params);
+        const data = await retryQuery(async () => {
+          return haravanClient.article.getArticles(blogId, params);
+        }, ArticleSyncService.CONFIG.ARTICLE_MAX_RETRIES, ArticleSyncService.CONFIG.ARTICLE_RETRY_DELAY);
+
         const articles = data.articles || [];
         all = all.concat(articles);
         if (articles.length < limit) hasMore = false;
@@ -90,7 +99,10 @@ export default class ArticleSyncService {
           page++;
           params.page = page;
         }
-      } catch {
+      } catch (error) {
+        Sentry.captureException(error, {
+          extra: { blogId, page, action: "fetchAllArticles" }
+        });
         hasMore = false;
       }
     }
@@ -159,31 +171,59 @@ export default class ArticleSyncService {
     return { matchedPairs, missingArticles, orphanEnArticles };
   }
 
+  async translateImageWithRetry(src, imageService) {
+    let fullSrc = src.startsWith("//") ? "https:" + src : src;
+
+    return retryQuery(async () => {
+      const newUrl = await imageService.translateImage(fullSrc, this.env);
+      return { src, newUrl: typeof newUrl === "string" ? newUrl : fullSrc, success: true };
+    }, ArticleSyncService.CONFIG.IMAGE_MAX_RETRIES, ArticleSyncService.CONFIG.IMAGE_RETRY_DELAY).catch(error => {
+      Sentry.captureException(error, {
+        extra: { src, action: "translateImageWithRetry" }
+      });
+      return { src, newUrl: fullSrc, success: false, error };
+    });
+  }
+
   async translateImagesInHtml(html, imageService) {
     if (!html) return html;
     const images = this.getImages(html);
     if (images.length === 0) return html;
 
-    let updatedHtml = html;
+    const batchSize = ArticleSyncService.CONFIG.IMAGE_BATCH_SIZE;
+    const results = [];
 
-    for (const src of images) {
-      let fullSrc = src.startsWith("//") ? "https:" + src : src;
-      const newUrl = await imageService.translateImage(fullSrc, this.env);
-      if (typeof newUrl === "string" && newUrl !== fullSrc) {
+    for (let i = 0; i < images.length; i += batchSize) {
+      const batch = images.slice(i, i + batchSize);
+      const batchResults = await Promise.allSettled(
+        batch.map(src => this.translateImageWithRetry(src, imageService))
+      );
+      results.push(...batchResults.map(r => r.status === "fulfilled" ? r.value : null));
+    }
+
+    let updatedHtml = html;
+    for (const result of results) {
+      if (result && result.success && result.newUrl !== result.src) {
         updatedHtml = updatedHtml.replace(
-          new RegExp(src.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"),
-          newUrl
+          new RegExp(result.src.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"),
+          result.newUrl
         );
       }
     }
+
     return updatedHtml;
   }
 
   async translateFeaturedImage(src, imageService) {
     if (!src) return null;
     const fullSrc = src.startsWith("//") ? "https:" + src : src;
-    const newUrl = await imageService.translateImage(fullSrc, this.env);
-    return typeof newUrl === "string" ? newUrl : src;
+
+    const result = await this.translateImageWithRetry(fullSrc, imageService);
+    return result.success ? result.newUrl : fullSrc;
+  }
+
+  async sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
   }
 
   async sync() {
@@ -236,6 +276,7 @@ export default class ArticleSyncService {
                   author: pair.vi.author,
                   image: featuredImage ? { src: featuredImage } : null
                 });
+                await this.sleep(ArticleSyncService.CONFIG.API_REQUEST_DELAY);
               }
             } catch (error) {
               Sentry.captureException(error, {
@@ -253,6 +294,7 @@ export default class ArticleSyncService {
           for (const orphan of orphanEnArticles) {
             try {
               await haravanClient.article.deleteArticle(enId, orphan.id);
+              await this.sleep(ArticleSyncService.CONFIG.API_REQUEST_DELAY);
             } catch (error) {
               Sentry.captureException(error, {
                 extra: {
@@ -282,6 +324,7 @@ export default class ArticleSyncService {
                 published_at: vi.published_at,
                 image: featuredImage ? { src: featuredImage } : null
               });
+              await this.sleep(ArticleSyncService.CONFIG.API_REQUEST_DELAY);
             } catch (error) {
               Sentry.captureException(error, {
                 extra: {

--- a/src/services/haravan/articles/article-sync-service.js
+++ b/src/services/haravan/articles/article-sync-service.js
@@ -209,7 +209,7 @@ export default class ArticleSyncService {
 
         try {
           const { matchedPairs, missingArticles, orphanEnArticles } =
-            await this.checkBlogPair(haravanClient, viId, enId, dateRange, null);
+            await this.checkBlogPair(haravanClient, viId, enId, dateRange);
 
           for (const pair of matchedPairs) {
             try {

--- a/src/services/media/image-translation-service.js
+++ b/src/services/media/image-translation-service.js
@@ -162,47 +162,33 @@ export default class ImageTranslationService {
   }
 
   /**
-   * Build the expected EN filename from VI filename.
-   * VI: {filename}.png → EN: en_{filename}.png
+   * Build the expected EN filename from VI filename and content hash.
+   * VI: {filename}.png → EN: en_{filename}_{hash}.png
    *
    * @param {string} viFilename
+   * @param {string} hash
    * @returns {string}
    */
-  getTranslatedFilename(viFilename) {
+  getTranslatedFilename(viFilename, hash) {
     const nameWithoutExt = viFilename.substring(0, viFilename.lastIndexOf("."));
     const extension = viFilename.split(".").pop();
-    return `en_${nameWithoutExt}.${extension}`;
+    return `en_${nameWithoutExt}_${hash}.${extension}`;
   }
 
   /**
-   * Check if translated image already exists in R2.
+   * Compute SHA-256 hash of image buffer.
    *
-   * @param {string} enFilename
-   * @param {Object} env
-   * @returns {Promise<boolean>}
+   * @param {Uint8Array} buffer
+   * @returns {Promise<string>}
    */
-  async isTranslatedImageExists(enFilename, env) {
-    const storage = new WebsiteR2StorageService(env);
-    const key = `${storage.prefix}/${enFilename}`;
-    const object = await storage.bucket.head(key);
-    return object !== null;
+  async computeHash(buffer) {
+    const hashBuffer = await crypto.subtle.digest("SHA-256", buffer);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    return hashArray.map(b => b.toString(16).padStart(2, "0")).join("").substring(0, 8);
   }
 
   /**
-   * Get public URL for translated image.
-   *
-   * @param {string} enFilename
-   * @param {Object} env
-   * @returns {string}
-   */
-  getTranslatedImageUrl(enFilename, env) {
-    const storage = new WebsiteR2StorageService(env);
-    const key = `${storage.prefix}/${enFilename}`;
-    return `${env.R2_JEMMIA_WEBSITE_PUBLIC_URL}/${key}`;
-  }
-
-  /**
-   * Full translation pipeline with signature-based cache.
+   * Full translation pipeline with content-based cache.
    *
    * @param {File|string} image - File object or image URL
    * @param {Object} env
@@ -222,7 +208,8 @@ export default class ImageTranslationService {
       imageName = image.name || "image.jpg";
     }
 
-    const enFilename = this.getTranslatedFilename(imageName);
+    const hash = await this.computeHash(imageBuffer);
+    const enFilename = this.getTranslatedFilename(imageName, hash);
 
     if (await this.isTranslatedImageExists(enFilename, env)) {
       return this.getTranslatedImageUrl(enFilename, env);

--- a/src/services/media/image-translation-service.js
+++ b/src/services/media/image-translation-service.js
@@ -187,13 +187,16 @@ export default class ImageTranslationService {
     return hashArray.map(b => b.toString(16).padStart(2, "0")).join("").substring(0, 8);
   }
 
-  /**
-   * Full translation pipeline with content-based cache.
-   *
-   * @param {File|string} image - File object or image URL
-   * @param {Object} env
-   * @returns {Promise<string|null>}
-   */
+  async isTranslatedImageExists(filename, env) {
+    const storage = new WebsiteR2StorageService(env);
+    return await storage.exists(filename);
+  }
+
+  async getTranslatedImageUrl(filename, env) {
+    const storage = new WebsiteR2StorageService(env);
+    return storage.getPublicUrl(filename);
+  }
+
   async translateImage(image, env) {
     let imageBuffer;
     let imageName;

--- a/src/services/media/image-translation-service.js
+++ b/src/services/media/image-translation-service.js
@@ -4,7 +4,6 @@ import {
   getGoogleGenerativeAIModel
 } from "services/utils/llm-helper";
 import { AI_MODELS } from "src/constants/ai-proxy";
-import { v4 as uuidv4 } from "uuid";
 import { WebsiteR2StorageService } from "services/r2-object/website/website-r2-storage-service";
 import * as Sentry from "@sentry/cloudflare";
 
@@ -163,7 +162,47 @@ export default class ImageTranslationService {
   }
 
   /**
-   * Full translation pipeline.
+   * Build the expected EN filename from VI filename.
+   * VI: {filename}.png → EN: en_{filename}.png
+   *
+   * @param {string} viFilename
+   * @returns {string}
+   */
+  getTranslatedFilename(viFilename) {
+    const nameWithoutExt = viFilename.substring(0, viFilename.lastIndexOf("."));
+    const extension = viFilename.split(".").pop();
+    return `en_${nameWithoutExt}.${extension}`;
+  }
+
+  /**
+   * Check if translated image already exists in R2.
+   *
+   * @param {string} enFilename
+   * @param {Object} env
+   * @returns {Promise<boolean>}
+   */
+  async isTranslatedImageExists(enFilename, env) {
+    const storage = new WebsiteR2StorageService(env);
+    const key = `${storage.prefix}/${enFilename}`;
+    const object = await storage.bucket.head(key);
+    return object !== null;
+  }
+
+  /**
+   * Get public URL for translated image.
+   *
+   * @param {string} enFilename
+   * @param {Object} env
+   * @returns {string}
+   */
+  getTranslatedImageUrl(enFilename, env) {
+    const storage = new WebsiteR2StorageService(env);
+    const key = `${storage.prefix}/${enFilename}`;
+    return `${env.R2_JEMMIA_WEBSITE_PUBLIC_URL}/${key}`;
+  }
+
+  /**
+   * Full translation pipeline with signature-based cache.
    *
    * @param {File|string} image - File object or image URL
    * @param {Object} env
@@ -183,6 +222,12 @@ export default class ImageTranslationService {
       imageName = image.name || "image.jpg";
     }
 
+    const enFilename = this.getTranslatedFilename(imageName);
+
+    if (await this.isTranslatedImageExists(enFilename, env)) {
+      return this.getTranslatedImageUrl(enFilename, env);
+    }
+
     const metadata = await this.extractMetadata(imageBuffer, env);
 
     if (metadata.length === 0) {
@@ -195,17 +240,8 @@ export default class ImageTranslationService {
       env
     );
 
-    const uniqueId = uuidv4().split("-")[0];
-    const extension = imageName.split(".").pop();
-    const nameWithoutExt = imageName.substring(0, imageName.lastIndexOf("."));
-    const outputFilename = `en_${nameWithoutExt}_${uniqueId}.${extension}`;
-
-    // Save to R2
     const storage = new WebsiteR2StorageService(env);
-    const publicUrl = await storage.upload(
-      outputFilename,
-      translatedImageBuffer
-    );
+    const publicUrl = await storage.upload(enFilename, translatedImageBuffer);
 
     return publicUrl;
   }


### PR DESCRIPTION
## Summary
- Implemented signature-based caching for image translation to reduce AI costs and storage usage.
- Fixed translated image naming convention to `en_{filename}.ext` (removed uniqueId).
- Updated sync logic to fetch articles from 21h yesterday to 21h today.
- Modified article matching to fetch all EN articles regardless of date to prevent creating duplicate EN articles when VI is edited days later.

## Changes
- `src/services/media/image-translation-service.js`: Added cache check methods, updated naming logic.
- `src/services/haravan/articles/article-sync-service.js`: Adjusted date range calculation, separated date range logic for VI/EN fetching.
