### PR TITLE
fix: enable timeout reset during retry attempts in google merchant sync

### DIFF
--- a/src/services/google/google-merchant-service.js
+++ b/src/services/google/google-merchant-service.js
@@ -13,6 +13,7 @@ export default class GoogleMerchantService {
       timeout: 30000
     }, {
       retries: 5,
+      shouldResetTimeout: true,
       retryDelay: (retryCount) => {
         return Math.pow(2, retryCount) * 1000;
       },


### PR DESCRIPTION
…rvice