### PR TITLE
fix: add missing exists method to R2StorageService and fix image

### DIFF
--- a/src/services/media/image-translation-service.js
+++ b/src/services/media/image-translation-service.js
@@ -189,12 +189,14 @@ export default class ImageTranslationService {
 
   async isTranslatedImageExists(filename, env) {
     const storage = new WebsiteR2StorageService(env);
-    return await storage.exists(filename);
+    const key = `${storage.prefix}/${filename}`;
+    return await storage.exists(key);
   }
 
   async getTranslatedImageUrl(filename, env) {
     const storage = new WebsiteR2StorageService(env);
-    return storage.getPublicUrl(filename);
+    const key = `${storage.prefix}/${filename}`;
+    return `${env.R2_JEMMIA_WEBSITE_PUBLIC_URL}/${key}`;
   }
 
   async translateImage(image, env) {

--- a/src/services/r2-object/core/r2-storage-service.js
+++ b/src/services/r2-object/core/r2-storage-service.js
@@ -20,6 +20,25 @@ export class R2StorageService {
   }
 
   /**
+   * Check if an object exists in R2.
+   * @param {string} key - The object key.
+   * @returns {Promise<boolean>}
+   */
+  async exists(key) {
+    if (!key) {
+      return false;
+    }
+
+    try {
+      const object = await this.bucket.head(key);
+      return object !== null;
+    } catch (err) {
+      Sentry.captureException(err);
+      return false;
+    }
+  }
+
+  /**
    * Get an object from R2.
    * @param {string} key - The object key.
    * @returns {Promise<ArrayBuffer|null>}


### PR DESCRIPTION
translation storage calls

- Add exists() method using bucket.head() to check object existence
- Fix isTranslatedImageExists to include storage prefix in key lookup
- Fix getTranslatedImageUrl to build public URL directly instead of calling non-existent getPublicUrl()