### PR TITLE
Fix/call log/duplicate phone leading to duplicate lead

### DIFF
--- a/src/services/erp/contacts/contact/contact.js
+++ b/src/services/erp/contacts/contact/contact.js
@@ -170,7 +170,8 @@ export default class ContactService {
   }
 
   async processCallLogContact(data, lead, source) {
-    const phone = data.type === "Incoming" ? data.from : data.to;
+    const initialPhone = data.type === "Incoming" ? data.from : data.to;
+    const phone = normalizeToStandardFormat(initialPhone);
     const contactData = {
       doctype: this.doctype,
       stringee_id: data.id,

--- a/src/services/erp/telephony/call-log/call-log.js
+++ b/src/services/erp/telephony/call-log/call-log.js
@@ -1,7 +1,7 @@
 import FrappeClient from "src/frappe/frappe-client";
 import StringeeClient from "src/stringee/stringee-client";
 import { timestampToDatetime } from "src/stringee/utils/datetime";
-import { normalizePhoneNumber } from "src/stringee/utils/phone-number";
+import { normalizeToStandardFormat } from "services/utils/phone-utils";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc.js";
 
@@ -58,8 +58,8 @@ export default class CallLogService {
     return {
       doctype: this.doctype,
       id: callLog.id,
-      from: normalizePhoneNumber(callLog.from_number),
-      to: normalizePhoneNumber(callLog.to_number),
+      from: normalizeToStandardFormat(callLog.from_number),
+      to: normalizeToStandardFormat(callLog.to_number) || callLog.to_number,
       start_time: timestampToDatetime(callLog.start_time),
       end_time: timestampToDatetime(callLog.stop_time),
       duration: callLog.answer_duration,


### PR DESCRIPTION
#### Changes
- Fix: create Call Log on ERP with latest phone format
  - This causing Lead got duplicated create with `phone`  that have `84` and `09` 

Task: [Link](https://applink.larksuite.com/client/todo/detail?guid=bc94b9a1-0135-4c5c-badb-a1490787c251&suite_entity_num=t120012)
Sentry: [Link](https://jemmia.sentry.io/issues/7392940988/)