### PR TITLE
feat(capi): Add Pancake POS sync for Haravan orders

### DIFF
--- a/src/controllers/webhook/haravan/erp/order.js
+++ b/src/controllers/webhook/haravan/erp/order.js
@@ -25,6 +25,7 @@ export default class HaravanERPOrderController {
       }
 
       await ctx.env["ERPNEXT_ORDER_CREATION_QUEUE"].send(data);
+      await ctx.env["PANCAKE_POS_SYNC_QUEUE"].send(data);
       return ctx.json({ message: "Message sent to queue", status: 200 });
     } catch (e) {
       Sentry.captureException(e);

--- a/src/services/ecommerce/enum.js
+++ b/src/services/ecommerce/enum.js
@@ -10,3 +10,23 @@ export const HARAVAN_DISPATCH_TYPE_ZALO_MSG = {
   PAID: "PAID",
   REMIND_PAY: "REMIND_PAY"
 };
+
+export const HARAVAN_FINANCIAL_STATUS = {
+  PENDING: "pending",
+  PARTIALLY_PAID: "partially_paid",
+  PAID: "paid",
+  PARTIALLY_REFUNDED: "partially_refunded",
+  REFUNDED: "refunded",
+  VOIDED: "voided"
+};
+
+export const HARAVAN_CANCELLED_STATUS = {
+  CANCELLED: "cancelled",
+  UNCANCELLED: "uncancelled"
+};
+
+export const HARAVAN_FULFILLMENT_STATUS = {
+  UNSHIPPED: "unshipped",
+  SHIPPED: "shipped",
+  PARTIAL: "partial"
+};

--- a/src/services/haravan/dtos/haravan-order-payload.ts
+++ b/src/services/haravan/dtos/haravan-order-payload.ts
@@ -1,0 +1,206 @@
+export interface HaravanAddress {
+  address1?: string | null;
+  address2?: string | null;
+  city?: string | null;
+  company?: string | null;
+  country?: string | null;
+  country_code?: string | null;
+  default?: boolean | null;
+  district?: string | null;
+  district_code?: string | null;
+  first_name?: string | null;
+  id?: number | null;
+  last_name?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  name?: string | null;
+  phone?: string | null;
+  province?: string | null;
+  province_code?: string | null;
+  ward?: string | null;
+  ward_code?: string | null;
+  zip?: string | null;
+}
+
+export interface HaravanClientDetails {
+  accept_language?: string | null;
+  browser_height?: number | null;
+  browser_ip?: string | null;
+  browser_width?: number | null;
+  session_hash?: string | null;
+  user_agent?: string | null;
+}
+
+export interface HaravanCustomer {
+  accepts_marketing?: boolean | null;
+  addresses?: HaravanAddress[] | null;
+  birthday?: string | null;
+  created_at?: string | null;
+  default_address?: HaravanAddress | null;
+  email?: string | null;
+  first_name?: string | null;
+  gender?: string | null;
+  id?: number | null;
+  last_name?: string | null;
+  last_order_date?: string | null;
+  last_order_id?: number | null;
+  last_order_name?: string | null;
+  multipass_identifier?: string | null;
+  note?: string | null;
+  orders_count?: number | null;
+  order_count?: number | null;
+  phone?: string | null;
+  state?: string | null;
+  tags?: string | null;
+  total_spent?: number | null;
+  updated_at?: string | null;
+  verified_email?: boolean | null;
+}
+
+export interface HaravanLineItemImage {
+  src?: string | null;
+  [key: string]: unknown;
+}
+
+export interface HaravanLineItem {
+  actual_price?: number | null;
+  applied_discounts?: unknown;
+  barcode?: string | null;
+  discount_allocations?: unknown;
+  fulfillable_quantity?: number | null;
+  fulfillment_service?: string | null;
+  fulfillment_status?: string | null;
+  gift_card?: boolean | null;
+  grams?: number | null;
+  id?: number | null;
+  image?: HaravanLineItemImage | Record<string, unknown> | null;
+  ma_cost_amount?: number | null;
+  name?: string | null;
+  not_allow_promotion?: boolean | null;
+  price?: number | null;
+  price_original?: number | null;
+  price_promotion?: number | null;
+  product_exists?: boolean | null;
+  product_id?: number | null;
+  properties?: unknown[] | null;
+  quantity?: number | null;
+  requires_shipping?: boolean | null;
+  sku?: string | null;
+  tax_lines?: unknown;
+  taxable?: boolean | null;
+  title?: string | null;
+  total_discount?: number | null;
+  type?: string | null;
+  variant_id?: number | null;
+  variant_title?: string | null;
+  vendor?: string | null;
+}
+
+export interface HaravanTransaction {
+  amount?: number | null;
+  authorization?: string | null;
+  created_at?: string | null;
+  currency?: string | null;
+  device_id?: string | null;
+  external_payment_type?: string | null;
+  external_transaction_id?: string | null;
+  gateway?: string | null;
+  haravan_transaction_id?: string | null;
+  id?: number | null;
+  kind?: string | null;
+  location_id?: number | null;
+  order_id?: number | null;
+  parent_id?: number | null;
+  payment_details?: unknown;
+  receipt?: unknown;
+  status?: string | null;
+  user_id?: number | null;
+}
+
+export interface HaravanShippingLine {
+  code?: string | null;
+  price?: number | string | null;
+  source?: string | null;
+  title?: string | null;
+}
+
+export interface HaravanOrderPayload {
+  assigned_location_at?: string | null;
+  assigned_location_id?: number | null;
+  assigned_location_name?: string | null;
+  billing_address?: HaravanAddress | null;
+  browser_ip?: string | null;
+  buyer_accepts_marketing?: boolean | null;
+  cancel_reason?: string | null;
+  cancelled_at?: string | null;
+  cancelled_status?: string | null;
+  cart_token?: string | null;
+  checkout_token?: string | null;
+  client_details?: HaravanClientDetails | null;
+  closed_at?: string | null;
+  closed_status?: string | null;
+  confirm_user?: number | null;
+  confirmed_at?: string | null;
+  confirmed_status?: string | null;
+  contact_email?: string | null;
+  created_at?: string | null;
+  currency?: string | null;
+  customer?: HaravanCustomer | null;
+  discount_applications?: unknown;
+  discount_codes?: unknown[] | null;
+  email?: string | null;
+  exported_confirm_at?: string | null;
+  financial_status: string;
+  fulfillment_status?: string | null;
+  fulfillments?: unknown[] | null;
+  gateway?: string | null;
+  gateway_code?: string | null;
+  haravan_topic: string;
+  id: number;
+  landing_site?: string | null;
+  landing_site_ref?: string | null;
+  line_items?: HaravanLineItem[] | null;
+  location_id?: number | null;
+  location_name?: string | null;
+  name?: string | null;
+  note?: string | null;
+  note_attributes?: unknown[] | null;
+  number?: number | null;
+  order_number?: string | null;
+  order_processing_status?: string | null;
+  payment_url?: string | null;
+  prev_order_date?: string | null;
+  prev_order_id?: number | null;
+  prev_order_number?: string | null;
+  processing_method?: string | null;
+  redeem_model?: unknown | null;
+  referring_site?: string | null;
+  ref_order_date?: string | null;
+  ref_order_id?: number | null;
+  ref_order_number?: string | null;
+  refunds?: unknown[] | null;
+  risk_level?: string | null;
+  shipping_address?: HaravanAddress | null;
+  shipping_lines?: HaravanShippingLine[] | null;
+  source?: string | null;
+  source_name?: string | null;
+  subtotal_price?: number | string | null;
+  tags?: string | null;
+  tax_lines?: unknown;
+  taxes_included?: boolean | null;
+  token?: string | null;
+  total_discounts?: number | string | null;
+  total_line_items_price?: number | string | null;
+  total_price?: number | string | null;
+  total_tax?: number | string | null;
+  total_weight?: number | string | null;
+  transactions?: HaravanTransaction[] | null;
+  updated_at?: string | null;
+  utm_campaign?: string | null;
+  utm_content?: string | null;
+  utm_medium?: string | null;
+  utm_source?: string | null;
+  utm_term?: string | null;
+  user_id?: number | null;
+  device_id?: string | null;
+}

--- a/src/services/haravan/utils/haravan-money.ts
+++ b/src/services/haravan/utils/haravan-money.ts
@@ -1,0 +1,6 @@
+export function haravanMoneyToNumber(value: unknown): number {
+  if (value == null) return 0;
+  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
+  const n = parseFloat(String(value).trim());
+  return Number.isFinite(n) ? n : 0;
+}

--- a/src/services/haravan/webhook-order.ts
+++ b/src/services/haravan/webhook-order.ts
@@ -1,0 +1,2 @@
+export * from "./dtos/haravan-order-payload";
+export { haravanMoneyToNumber } from "./utils/haravan-money";

--- a/src/services/haravan/webhook-order.ts
+++ b/src/services/haravan/webhook-order.ts
@@ -1,2 +1,2 @@
-export * from "./dtos/haravan-order-payload";
-export { haravanMoneyToNumber } from "./utils/haravan-money";
+export * from "services/haravan/dtos/haravan-order-payload";
+export { haravanMoneyToNumber } from "services/haravan/utils/haravan-money";

--- a/src/services/pancake/pos/pancake-pos-sync-service.ts
+++ b/src/services/pancake/pos/pancake-pos-sync-service.ts
@@ -1,0 +1,203 @@
+import Database from "services/database";
+import PancakePosClient, { CreateOrderPayload, OrderItem } from "services/pancake/pos/pancake-pos-client";
+import { haravanMoneyToNumber, HaravanOrderPayload } from "services/haravan/webhook-order";
+import { ResolvedLead } from "services/pancake/pos/types";
+import {
+  HARAVAN_CANCELLED_STATUS,
+  HARAVAN_TOPIC
+} from "services/ecommerce/enum";
+import { normalizeToStandardFormat } from "services/utils/phone-utils";
+
+const POS_STATUS = {
+  NEW: 0,
+  CANCELED: 6
+} as const;
+
+const PANCAKE_POS_BASE_ORDER_VARIATION_ID = "1b756676-3314-43f5-b03e-4829a166f779";
+const PANCAKE_POS_BASE_ORDER_PRODUCT_ID = "2cc80df9-72ef-4267-8577-1ed9c1d2035d";
+
+export default class PancakePOSSyncService {
+  private db: ReturnType<typeof Database.instance>;
+  private client: PancakePosClient;
+
+  constructor(env: any) {
+    this.db = Database.instance(env);
+    this.client = new PancakePosClient(env.PANCAKE_POS_API_KEY);
+  }
+
+  static async dequeueOrderQueue(batch: any, env: any): Promise<void> {
+    const service = new PancakePOSSyncService(env);
+    for (const msg of batch.messages) {
+      await service.processOrder(msg.body);
+      msg.ack();
+    }
+  }
+
+  async processOrder(order: HaravanOrderPayload): Promise<void> {
+    const ctx = await this.resolveSyncContext(order);
+    if (!ctx) return;
+    const { shopId, lead } = ctx;
+
+    if (order.haravan_topic === HARAVAN_TOPIC.CREATED) {
+      await this.syncOrderCreate(order, shopId, lead);
+    } else if (order.haravan_topic === HARAVAN_TOPIC.UPDATED) {
+      await this.syncOrderUpdate(order, shopId);
+    }
+  }
+
+  private async resolveSyncContext(order: HaravanOrderPayload) {
+    if (!order.customer?.phone) return;
+
+    const lead = await this.resolveAdsId(order.customer.phone);
+    if (!lead) return;
+
+    const shopId = await this.resolveShopId(lead.pageId);
+    if (!shopId) return;
+
+    return {
+      lead, shopId
+    };
+  }
+
+  private async resolveAdsId(customerPhone: string): Promise<ResolvedLead | null> {
+    const target = normalizeToStandardFormat(customerPhone);
+    if (!target) return null;
+
+    const pageCustomer = await this.db.page_customer.findFirst({
+      where: {
+        phone_numbers_normalize: {
+          array_contains: [target]
+        }
+      },
+      orderBy: { updated_at: "desc" },
+      select: { customer_id: true }
+    });
+    if (!pageCustomer?.customer_id) return null;
+
+    const conversation = await this.db.conversation.findFirst({
+      where: {
+        customer_id: pageCustomer.customer_id,
+        type: "INBOX"
+      },
+      orderBy: { updated_at: "desc" },
+      select: { id: true, page_id: true, ad_ids: true }
+    });
+    if (!conversation?.ad_ids) return null;
+
+    const adIds: string[] = Array.isArray(conversation.ad_ids)
+      ? (conversation.ad_ids as string[]).filter(Boolean)
+      : [];
+    if (adIds.length === 0) return null;
+
+    return {
+      conversationId: conversation.id ?? "",
+      pageId: conversation.page_id ?? "",
+      adIds
+    };
+  }
+
+  private async resolveShopId(pageId: string): Promise<number | null> {
+    const page = await this.db.page.findFirst({
+      where: { id: pageId },
+      select: { pos_shop_id: true }
+    });
+    return page?.pos_shop_id ?? null;
+  }
+
+  private async syncOrderCreate(order: HaravanOrderPayload, shopId: number, lead: ResolvedLead): Promise<void> {
+    const existing = await this.db.pancakePOSOrderSync.findUnique({
+      where: { haravan_order_id: BigInt(order.id) }
+    });
+    if (existing?.pancake_order_id) return;
+
+    const status = this.mapStatus(order.cancelled_status);
+    const payload = this.buildCreatePayload({ order, lead, status });
+    const posOrder = await this.client.createOrder(shopId, payload);
+
+    await this.db.pancakePOSOrderSync.upsert({
+      where: { haravan_order_id: BigInt(order.id) },
+      create: {
+        haravan_order_id: BigInt(order.id),
+        pancake_order_id: posOrder.id,
+        shop_id: shopId,
+        ads_id: lead.adIds[0],
+        status,
+        synced_at: new Date()
+      },
+      update: {
+        pancake_order_id: posOrder.id,
+        shop_id: shopId,
+        ads_id: lead.adIds[0],
+        status,
+        synced_at: new Date(),
+        updated_at: new Date()
+      }
+    });
+  }
+
+  private buildCreatePayload({
+    order,
+    lead,
+    status
+  }: {
+    order: HaravanOrderPayload;
+    lead: ResolvedLead;
+    status: number;
+  }): CreateOrderPayload {
+    const customer = order.customer;
+    const fullName = [customer?.first_name, customer?.last_name].filter(Boolean).join(" ") || undefined;
+    const shippingFee = (order.shipping_lines ?? []).reduce(
+      (total, line) => total + haravanMoneyToNumber(line.price),
+      0
+    );
+
+    return {
+      bill_full_name: fullName,
+      bill_phone_number: customer?.phone ?? undefined,
+      conversation_id: lead.conversationId,
+      note: order.note,
+      status,
+      shipping_fee: shippingFee,
+      ad_id: lead.adIds[0],
+      page_id: lead.pageId,
+      items: [this.buildBaseProductItem(order)]
+    };
+  }
+
+  private buildBaseProductItem(order: HaravanOrderPayload): OrderItem {
+    return {
+      discount_each_product: haravanMoneyToNumber(order.total_discounts),
+      quantity: 1,
+      variation_info: {
+        name: "Giá trị đơn hàng",
+        retail_price: haravanMoneyToNumber(order.total_price)
+      },
+      variation_id: PANCAKE_POS_BASE_ORDER_VARIATION_ID,
+      product_id: PANCAKE_POS_BASE_ORDER_PRODUCT_ID
+    };
+  }
+
+  private async syncOrderUpdate(order: HaravanOrderPayload, shopId: number): Promise<void> {
+    const sync = await this.db.pancakePOSOrderSync.findUnique({
+      where: { haravan_order_id: BigInt(order.id) }
+    });
+    if (!sync?.pancake_order_id) return;
+
+    const status = this.mapStatus(order.cancelled_status);
+    if (sync.status === status) return;
+
+    await this.client.updateOrderStatus(sync.shop_id ?? shopId, sync.pancake_order_id, status);
+    await this.db.pancakePOSOrderSync.update({
+      where: { haravan_order_id: BigInt(order.id) },
+      data: { status, updated_at: new Date() }
+    });
+  }
+
+  private mapStatus(cancelledStatus: string | null): number {
+    const normalizedCancelledStatus = cancelledStatus?.toLowerCase() ?? null;
+
+    if (normalizedCancelledStatus === HARAVAN_CANCELLED_STATUS.CANCELLED) return POS_STATUS.CANCELED;
+
+    return POS_STATUS.NEW;
+  }
+}

--- a/src/services/pancake/pos/types.ts
+++ b/src/services/pancake/pos/types.ts
@@ -1,0 +1,5 @@
+export interface ResolvedLead {
+  conversationId: string;
+  pageId: string;
+  adIds: string[];
+}

--- a/src/services/queue-handler.js
+++ b/src/services/queue-handler.js
@@ -31,6 +31,9 @@ export default {
     case "erpnext-order-creation":
       await ERP.Selling.SalesOrderService.dequeueOrderQueue(batch, env);
       break;
+    case "pancake-pos-sync":
+      await Pancake.PancakePOSSyncService.dequeueOrderQueue(batch, env);
+      break;
     case "message":
       await Pancake.ConversationService.dequeueMessageSyncCustomerToLeadCRM(batch, env);
       break;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,12 +4,9 @@
   "main": "src/index.js",
   "compatibility_date": "2025-05-20",
   "upload_source_maps": true,
-  "compatibility_flags": [
-    "nodejs_compat",
-    "durable_object_alarms"
-  ],
+  "compatibility_flags": ["nodejs_compat", "durable_object_alarms"],
   "limits": {
-    "cpu_ms": 300000, // 300 seconds = 5 minutes
+    "cpu_ms": 300000 // 300 seconds = 5 minutes
   },
   "assets": {
     "binding": "ASSETS",
@@ -67,10 +64,10 @@
     "DEFAULT_HARAVAN_JEWELRY_DISCOUNT_COLLECTION_ID": 31,
     "UPTIMEROBOT_API_KEY": "ur3236830-be8be169403c7dd3a91daeca",
     "GOOGLE_MERCHANT_ID": "183425778",
-    "LARK_RECALL_REDIRECT_URI":"https://fn.jemmia.vn/jemmia-shield/callback",
+    "LARK_RECALL_REDIRECT_URI": "https://fn.jemmia.vn/jemmia-shield/callback",
     "LARK_RECALL_VIEW_URL": "https://fn.jemmia.vn/jemmia-shield/message-recall/view",
-    "LARK_APP_SHIELD_ID":"cli_a9fd9bc9f7b9ded0",
-    "OAUTH_REDIRECT_ENDPOINT":"https://fn.jemmia.vn",
+    "LARK_APP_SHIELD_ID": "cli_a9fd9bc9f7b9ded0",
+    "OAUTH_REDIRECT_ENDPOINT": "https://fn.jemmia.vn",
     "HARAVAN_APP_URL": "https://jemmiavn.myharavan.com",
     "AI_PROXY_URL": "https://aiproxy.jemmia.vn",
     "GOOGLE_GENERATIVE_AI_URL": "https://generativelanguage.googleapis.com/v1beta"
@@ -177,7 +174,7 @@
     "bindings": [
       {
         "name": "DEBOUNCE",
-        "class_name": "DebounceDurableObject",
+        "class_name": "DebounceDurableObject"
       }
     ]
   },
@@ -270,6 +267,10 @@
       {
         "queue": "promotion-diamond-collect-sync",
         "binding": "PROMOTION_DIAMOND_COLLECT_SYNC_QUEUE"
+      },
+      {
+        "queue": "pancake-pos-sync",
+        "binding": "PANCAKE_POS_SYNC_QUEUE"
       }
     ],
     "consumers": [
@@ -408,12 +409,10 @@
   "migrations": [
     {
       "tag": "v1",
-      "new_classes": [
-        "DebounceDurableObject"
-      ]
+      "new_classes": ["DebounceDurableObject"]
     }
   ],
   "version_metadata": {
-    "binding": "CF_VERSION_METADATA",
-  },
+    "binding": "CF_VERSION_METADATA"
+  }
 }


### PR DESCRIPTION
Introduce a Pancake POS synchronization flow for Haravan webhooks. Adds a new PancakePOSSyncService to create/update POS orders (resolve lead/page, build payload, upsert pancakePOSOrderSync, map statuses), plus a small ResolvedLead type. Add Haravan DTOs and a haravanMoneyToNumber util and export them via a new webhook-order barrel. Wire the PANCAKE_POS_SYNC_QUEUE into the Haravan ERP order controller and the queue-handler. Also extend ecommerce enums with Haravan financial/fulfillment/cancelled statuses.