### PR TITLE
fix(pancake-pos-sync): prevent queue spam and duplicate order creation

### DIFF
--- a/src/controllers/webhook/haravan/erp/order.js
+++ b/src/controllers/webhook/haravan/erp/order.js
@@ -25,7 +25,9 @@ export default class HaravanERPOrderController {
       }
 
       await ctx.env["ERPNEXT_ORDER_CREATION_QUEUE"].send(data);
-      await ctx.env["PANCAKE_POS_SYNC_QUEUE"].send(data);
+      if (data.haravan_topic === HARAVAN_TOPIC.CREATED || data.haravan_topic === HARAVAN_TOPIC.UPDATED) {
+        await ctx.env["PANCAKE_POS_SYNC_QUEUE"].send(data);
+      }
       return ctx.json({ message: "Message sent to queue", status: 200 });
     } catch (e) {
       Sentry.captureException(e);

--- a/src/services/pancake/pos/pancake-pos-sync-service.ts
+++ b/src/services/pancake/pos/pancake-pos-sync-service.ts
@@ -145,37 +145,37 @@ export default class PancakePOSSyncService {
   private async syncOrderCreate(order: HaravanOrderPayload, shopId: number, lead: ResolvedLead): Promise<void> {
     const tag = `[PancakePOSSync] syncOrderCreate order=${order.id} shopId=${shopId}`;
 
-    const existing = await this.db.pancakePOSOrderSync.findUnique({
-      where: { haravan_order_id: BigInt(order.id) }
+    const status = this.mapStatus(order.cancelled_status);
+
+    // Claim the record before calling the API to prevent duplicate creates
+    // when the same order is queued more than once (e.g. Haravan webhook retries).
+    const record = await this.db.pancakePOSOrderSync.upsert({
+      where: { haravan_order_id: BigInt(order.id) },
+      create: {
+        haravan_order_id: BigInt(order.id),
+        shop_id: shopId,
+        ads_id: lead.adIds[0],
+        status,
+        synced_at: new Date()
+      },
+      update: {}
     });
-    if (existing?.pancake_order_id) {
-      console.warn(`${tag} skip: already synced pancake_order_id=${existing.pancake_order_id}`);
+
+    if (record.pancake_order_id) {
+      console.warn(`${tag} skip: already synced pancake_order_id=${record.pancake_order_id}`);
       return;
     }
 
-    const status = this.mapStatus(order.cancelled_status);
     const payload = this.buildCreatePayload({ order, lead, status });
 
     console.warn(`${tag} creating POS order conversationId=${lead.conversationId} adId=${lead.adIds[0]}`);
     const posOrder = await this.client.createOrder(shopId, payload);
     console.warn(`${tag} created pancake_order_id=${posOrder.id}`);
 
-    await this.db.pancakePOSOrderSync.upsert({
+    await this.db.pancakePOSOrderSync.update({
       where: { haravan_order_id: BigInt(order.id) },
-      create: {
-        haravan_order_id: BigInt(order.id),
+      data: {
         pancake_order_id: posOrder.id,
-        shop_id: shopId,
-        ads_id: lead.adIds[0],
-        status,
-        synced_at: new Date()
-      },
-      update: {
-        pancake_order_id: posOrder.id,
-        shop_id: shopId,
-        ads_id: lead.adIds[0],
-        status,
-        synced_at: new Date(),
         updated_at: new Date()
       }
     });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -294,6 +294,8 @@
       },
       {
         "queue": "pancake-pos-sync",
+        "retry_delay": 600,
+        "max_retries": 3,
         "max_batch_size": 1
       },
       {


### PR DESCRIPTION
- Add retry_delay=600 and max_retries=3 to consumer config to stop immediate retry storms when Pancake API is unavailable
- Only enqueue CREATED and UPDATED topics; other topics (PAID, etc.) were silently skipped by the consumer but still consumed queue capacity
- Pre-create DB record before calling Pancake API so duplicate webhooks from Haravan retries skip the API call instead of creating duplicate orders