### PR TITLE
feat (sales order debt): notify to sales admin to update debt progress of an order

### DIFF
--- a/src/services/erp/selling/index.js
+++ b/src/services/erp/selling/index.js
@@ -8,6 +8,7 @@ import PromotionService from "services/erp/selling/promotion/promotion";
 import SalesOrderItemService from "services/erp/selling/sales-order-item/sales-order-item";
 import BuybackExchangeSyncService from "services/erp/selling/buyback-exchange/buyback-exchange-sync-service";
 import MissingSerialNotificationService from "services/erp/selling/sales-order/missing-serial-notification";
+import DebtTrackingNotificationService from "src/services/erp/selling/order-and-debt-tracking/debt-tracking-notification-service";
 
 export default {
   SalesOrderService: SalesOrderService,
@@ -19,5 +20,6 @@ export default {
   PromotionService: PromotionService,
   SalesOrderItemService: SalesOrderItemService,
   BuybackExchangeSyncService: BuybackExchangeSyncService,
-  MissingSerialNotificationService: MissingSerialNotificationService
+  MissingSerialNotificationService: MissingSerialNotificationService,
+  DebtTrackingNotificationService: DebtTrackingNotificationService
 };

--- a/src/services/erp/selling/order-and-debt-tracking/debt-tracking-notification-service.js
+++ b/src/services/erp/selling/order-and-debt-tracking/debt-tracking-notification-service.js
@@ -11,12 +11,6 @@ import { stringSquishLarkMessage } from "services/utils/string-helper";
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
-const SPECIFIC_SALES_ADMIN = [
-  "tien.chau@jemmia.vn",
-  "trinh.ngo@jemmia.vn",
-  "thao.nguyen@jemmia.vn",
-  "hue.phan@jemmia.vn"
-];
 const VIETNAM_THURSDAY = 4;
 
 export default class DebtTrackingNotificationService {
@@ -41,19 +35,18 @@ export default class DebtTrackingNotificationService {
     const orders = await this._fetchDebtList(nextWednesday, false);
     if (!orders?.length) return;
 
-    const dynamicAdmins = orders.map(o => o.sales_person || o.owner).filter(Boolean);
-    const salesAdmins = [...new Set([...dynamicAdmins, ...SPECIFIC_SALES_ADMIN])];
-    const larkTags = await this._getLarkTagsForUsers(salesAdmins);
-
     const count = orders.length;
-    const tagString = larkTags?.length ? `${larkTags.join(" ")}\n` : "";
+    const stats = await this._getBranchStatsAndTags(orders);
 
     const message = stringSquishLarkMessage(`
-      ${tagString}
-      Jemmia Bot đã cập nhật danh sách công nợ tuần này,
-      các chị vào ERP cập nhật tình hình thu công nợ giúp Bot nha.
+      Jemmia Bot vừa cập nhật danh sách công nợ tuần này. Hiện có **${count}** đơn hàng cần cập nhật tình trạng thu tiền:
 
-      Có tổng cộng **${count}** đơn hàng cần check.
+      TP.HCM: **${stats.hcmCount}** đơn — ${stats.hcmTag}
+      Hà Nội: **${stats.hnCount}** đơn — ${stats.hnTag}
+      Cần Thơ: **${stats.ctCount}** đơn — ${stats.ctTag}
+      Khác: **${stats.otherCount}** đơn — ${stats.allTags}
+
+      Các chị vào ERP cập nhật giúp Bot nhé!
     `);
 
     await this._sendToLarksuite(message, {
@@ -72,13 +65,19 @@ export default class DebtTrackingNotificationService {
     const remainingOrders = orders?.length;
     if (!remainingOrders) return;
 
+    const stats = await this._getBranchStatsAndTags(orders);
+
     const message = stringSquishLarkMessage(`
-      Hôm nay còn **${remainingOrders}** đơn chưa cập nhật.
-      Mời các admin vào trang Admin để kiểm tra và cập nhật nhé!
+      ⏰ Hôm nay còn **${remainingOrders}** đơn chưa được cập nhật. Các chị hoàn thành trước **14:00** giúp Bot nha, để kịp tổng hợp báo cáo cuối ngày!
+
+      TP.HCM: **${stats.hcmCount}** đơn — ${stats.hcmTag}
+      Hà Nội: **${stats.hnCount}** đơn — ${stats.hnTag}
+      Cần Thơ: **${stats.ctCount}** đơn — ${stats.ctTag}
+      Khác: **${stats.otherCount}** đơn — ${stats.allTags}
     `);
 
     await this._sendToLarksuite(message, {
-      text: "👉 Trang Admin",
+      text: "👉 Kiểm tra đơn hàng trên ERP",
       url: `${this.erpBaseUrl}/desk/admin`
     });
   }
@@ -94,15 +93,38 @@ export default class DebtTrackingNotificationService {
     return res?.data;
   }
 
-  async _getLarkTagsForUsers(userIdentifiers) {
-    if (!userIdentifiers?.length) return [];
+  async _getBranchStatsAndTags(orders) {
+    let hcmCount = 0;
+    let hnCount = 0;
+    let ctCount = 0;
+    let otherCount = 0;
 
-    const users = await this.db.larksuite_users.findMany({
-      where: { enterprise_email: { in: userIdentifiers } },
-      select: { user_id: true }
+    orders.forEach(order => {
+      const address = order.billing_address || "";
+      if (address.includes("72 Nguyễn Cư Trinh")) hcmCount++;
+      else if (address.includes("63 Kim Mã")) hnCount++;
+      else if (address.includes("209 Đường 30 Tháng 4")) ctCount++;
+      else otherCount++;
     });
 
-    return users.filter(u => u.user_id).map(u => `<at id="${u.user_id}"></at>`);
+    const adminEmails = ["trinh.ngo@jemmia.vn", "hue.phan@jemmia.vn", "tien.chau@jemmia.vn"];
+    const users = await this.db.larksuite_users.findMany({
+      where: { enterprise_email: { in: adminEmails } },
+      select: { enterprise_email: true, user_id: true }
+    });
+
+    const adminTags = {};
+    users.forEach(u => { adminTags[u.enterprise_email] = `<at id="${u.user_id}"></at>`; });
+
+    const hcmTag = adminTags["trinh.ngo@jemmia.vn"];
+    const hnTag = adminTags["hue.phan@jemmia.vn"];
+    const ctTag = adminTags["tien.chau@jemmia.vn"];
+    const allTags = `${hcmTag} ${hnTag} ${ctTag}`;
+
+    return {
+      hcmCount, hnCount, ctCount, otherCount,
+      hcmTag, hnTag, ctTag, allTags
+    };
   }
 
   async _sendToLarksuite(messageText, buttonConfig = null) {

--- a/src/services/erp/selling/order-and-debt-tracking/debt-tracking-notification-service.js
+++ b/src/services/erp/selling/order-and-debt-tracking/debt-tracking-notification-service.js
@@ -1,0 +1,143 @@
+import FrappeClient from "src/frappe/frappe-client";
+import Database from "services/database";
+import LarksuiteService from "services/larksuite/lark";
+import { CHAT_GROUPS } from "services/larksuite/group-chat/group-management/constant";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc.js";
+import timezone from "dayjs/plugin/timezone.js";
+import { TIMEZONE_VIETNAM } from "src/constants";
+import { stringSquishLarkMessage } from "services/utils/string-helper";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const SPECIFIC_SALES_ADMIN = [
+  "tien.chau@jemmia.vn",
+  "trinh.ngo@jemmia.vn",
+  "thao.nguyen@jemmia.vn",
+  "hue.phan@jemmia.vn"
+];
+const VIETNAM_THURSDAY = 4;
+
+export default class DebtTrackingNotificationService {
+  constructor(env) {
+    this.env = env;
+    this.erpBaseUrl = env.JEMMIA_ERP_BASE_URL.replace(/\/$/, "");
+    this.frappeClient = new FrappeClient({
+      url: env.JEMMIA_ERP_BASE_URL,
+      apiKey: env.JEMMIA_ERP_API_KEY,
+      apiSecret: env.JEMMIA_ERP_API_SECRET
+    });
+    this.db = Database.instance(env);
+  }
+
+  /**
+   * 09:30 AM (GMT+7 Thursday) - Weekly Debt Notification
+   */
+  async notifyWeeklyAnnouncement() {
+    if (dayjs().tz(TIMEZONE_VIETNAM).day() !== VIETNAM_THURSDAY) return;
+
+    const nextWednesday = dayjs().tz(TIMEZONE_VIETNAM).add(6, "day").format("YYYY-MM-DD");
+    const orders = await this._fetchDebtList(nextWednesday, false);
+    if (!orders?.length) return;
+
+    const dynamicAdmins = orders.map(o => o.sales_person || o.owner).filter(Boolean);
+    const salesAdmins = [...new Set([...dynamicAdmins, ...SPECIFIC_SALES_ADMIN])];
+    const larkTags = await this._getLarkTagsForUsers(salesAdmins);
+
+    const count = orders.length;
+    const tagString = larkTags?.length ? `${larkTags.join(" ")}\n` : "";
+
+    const message = stringSquishLarkMessage(`
+      ${tagString}
+      Jemmia Bot đã cập nhật danh sách công nợ tuần này,
+      các chị vào ERP cập nhật tình hình thu công nợ giúp Bot nha.
+
+      Có tổng cộng **${count}** đơn hàng cần check.
+    `);
+
+    await this._sendToLarksuite(message, {
+      text: "👉 Kiểm tra đơn hàng trên ERP",
+      url: `${this.erpBaseUrl}/desk/admin`
+    });
+  }
+
+  /**
+   * 11:30 AM (Thursday) - Unchecked Orders Reminder
+   */
+  async notifyUncheckedOrdersReminder() {
+    if (dayjs().tz(TIMEZONE_VIETNAM).day() !== VIETNAM_THURSDAY) return;
+
+    const orders = await this._fetchDebtList(null, true);
+    const remainingOrders = orders?.length;
+    if (!remainingOrders) return;
+
+    const message = stringSquishLarkMessage(`
+      Hôm nay còn **${remainingOrders}** đơn chưa cập nhật.
+      Mời các admin vào trang Admin để kiểm tra và cập nhật nhé!
+    `);
+
+    await this._sendToLarksuite(message, {
+      text: "👉 Trang Admin",
+      url: `${this.erpBaseUrl}/desk/admin`
+    });
+  }
+
+  async _fetchDebtList(fromDate, fromTheLastCheck) {
+    const payload = {
+      cmd: "erpnext.selling.doctype.order_and_debt_tracking.custom.services.get_debt_list",
+      from_the_last_check: fromTheLastCheck
+    };
+    if (fromDate) payload.from_date = fromDate;
+
+    const res = await this.frappeClient.postRequest("", payload);
+    return res?.data;
+  }
+
+  async _getLarkTagsForUsers(userIdentifiers) {
+    if (!userIdentifiers?.length) return [];
+
+    const users = await this.db.larksuite_users.findMany({
+      where: { enterprise_email: { in: userIdentifiers } },
+      select: { user_id: true }
+    });
+
+    return users.filter(u => u.user_id).map(u => `<at id="${u.user_id}"></at>`);
+  }
+
+  async _sendToLarksuite(messageText, buttonConfig = null) {
+    const elements = [
+      {
+        tag: "div",
+        text: {
+          content: messageText,
+          tag: "lark_md"
+        }
+      },
+      {
+        tag: "action",
+        actions: [
+          {
+            tag: "button",
+            text: {
+              content: buttonConfig.text,
+              tag: "plain_text"
+            },
+            type: "primary",
+            url: buttonConfig.url
+          }
+        ]
+      }
+    ];
+
+    const larkClient = await LarksuiteService.createClientV2(this.env);
+    await larkClient.im.message.create({
+      params: { receive_id_type: "chat_id" },
+      data: {
+        receive_id: CHAT_GROUPS.ACCOUNTS_RECEIVABLE.chat_id,
+        msg_type: "interactive",
+        content: JSON.stringify({ elements })
+      }
+    });
+  }
+}

--- a/src/services/erp/selling/order-and-debt-tracking/debt-tracking-notification-service.js
+++ b/src/services/erp/selling/order-and-debt-tracking/debt-tracking-notification-service.js
@@ -16,7 +16,7 @@ const VIETNAM_THURSDAY = 4;
 export default class DebtTrackingNotificationService {
   constructor(env) {
     this.env = env;
-    this.erpBaseUrl = env.JEMMIA_ERP_BASE_URL.replace(/\/$/, "");
+    this.erpBaseUrl = env.JEMMIA_ERP_BASE_URL;
     this.frappeClient = new FrappeClient({
       url: env.JEMMIA_ERP_BASE_URL,
       apiKey: env.JEMMIA_ERP_API_KEY,

--- a/src/services/erp/selling/order-and-debt-tracking/debt-tracking-notification-service.js
+++ b/src/services/erp/selling/order-and-debt-tracking/debt-tracking-notification-service.js
@@ -51,7 +51,7 @@ export default class DebtTrackingNotificationService {
 
     await this._sendToLarksuite(message, {
       text: "👉 Kiểm tra đơn hàng trên ERP",
-      url: `${this.erpBaseUrl}/desk/admin`
+      url: `${this.erpBaseUrl}desk/admin`
     });
   }
 
@@ -78,7 +78,7 @@ export default class DebtTrackingNotificationService {
 
     await this._sendToLarksuite(message, {
       text: "👉 Kiểm tra đơn hàng trên ERP",
-      url: `${this.erpBaseUrl}/desk/admin`
+      url: `${this.erpBaseUrl}desk/admin`
     });
   }
 

--- a/src/services/larksuite/group-chat/group-management/constant.js
+++ b/src/services/larksuite/group-chat/group-management/constant.js
@@ -34,5 +34,9 @@ export const CHAT_GROUPS = {
   PROMOTION_SYNC_NOTIFICATION: {
     chat_id: "oc_0c56ab7868f6f90b3f3f6e0fdfd03482",
     group_name: "Hỗ trợ công thức tính CTKM"
+  },
+  ACCOUNTS_RECEIVABLE: {
+    chat_id: "oc_4117da9b37c4b5a82d92f1e712505c3c",
+    group_name: "[OPS] Công nợ khách hàng"
   }
 };


### PR DESCRIPTION
#### Changes
- Introduced service to fetch and notify sales admin to update debt progress of an order ( on ERP )

Task: [Link](https://applink.larksuite.com/client/todo/detail?guid=86a366a6-4816-4280-a0d3-9015cf2667a8&suite_entity_num=t120459)


<img width="1220" height="816" alt="img_v3_0212g_dfcb734f-217a-4dec-b154-e22a8d99c8hu" src="https://github.com/user-attachments/assets/bbf099d7-f530-4f61-b6d1-ef0ff3b8e0c8" />
