### PR TITLE
feat: add block size parameter to inventory queries and implement interleaved query logic

### DIFF
--- a/src/controllers/ecommerce/constant.js
+++ b/src/controllers/ecommerce/constant.js
@@ -3,7 +3,8 @@ export const API_CONFIG = {
   DEFAULT_FROM: 1,
   MIN_FROM: 1,
   MAX_LIMIT: 100,
-  MAX_SEARCH_LIMIT: 30
+  MAX_SEARCH_LIMIT: 30,
+  ROW_NUM_START_INDEX: 1
 };
 
 export const JEWELRY_IMAGE = {

--- a/src/controllers/ecommerce/jewelry-controller-v2.js
+++ b/src/controllers/ecommerce/jewelry-controller-v2.js
@@ -50,7 +50,8 @@ export default class JewelryControllerV2 {
       linked_collections: splitParams(params.linked_collections),
       matched_diamonds: params.matched_diamonds === "true",
       ring_sizes: splitParams(params.ring_sizes),
-      warehouse_ids: splitParams(params.warehouse_ids)
+      warehouse_ids: splitParams(params.warehouse_ids),
+      block_size: parseNumber(params.block_size, null)
     };
 
     const productService = new Ecommerce.ProductService(ctx.env);

--- a/src/services/ecommerce/product/utils/jewelry-v2.js
+++ b/src/services/ecommerce/product/utils/jewelry-v2.js
@@ -28,7 +28,7 @@ export function buildInventoryMetricsSql(opts = {}) {
   `;
 }
 
-export function buildQueryV2(jsonParams) {
+function buildBaseQueryV2(jsonParams) {
   const {
     filterSql,
     sortSql,
@@ -238,6 +238,67 @@ export function buildQueryV2(jsonParams) {
   `;
 
   return { dataSql, countSql };
+}
+
+export function buildInterleavedQueryV2(jsonParams) {
+  const productTypes = jsonParams.product_types || [];
+  const blockSize = jsonParams.block_size;
+
+  const M = productTypes.length;
+  const B = blockSize;
+  const cycleSize = M * B;
+
+  const from = jsonParams.pagination?.from - 1;
+  const limit = jsonParams.pagination?.limit;
+  const to = from + limit;
+
+  const max_rn = Math.ceil(to / cycleSize) * B;
+
+  const queries = productTypes.map((type, t) => {
+    const singleTypeParams = {
+      ...jsonParams,
+      product_types: [type],
+      pagination: {
+        from: 1,
+        limit: max_rn
+      }
+    };
+    const { dataSql: subDataSql } = buildBaseQueryV2(singleTypeParams);
+    return { subDataSql, t };
+  });
+
+  const unionSql = Prisma.join(
+    queries.map(q => Prisma.sql`
+      SELECT *, 
+             ROW_NUMBER() OVER () as rn, 
+             ${q.t}::integer as type_idx 
+      FROM (${q.subDataSql}) AS sub_t
+    `),
+    " UNION ALL "
+  );
+
+  const dataSql = Prisma.sql`
+    SELECT * FROM (
+      ${unionSql}
+    ) AS ranked
+    ORDER BY (rn - 1) / ${B}::integer ASC, type_idx ASC, rn ASC
+    LIMIT ${limit} OFFSET ${from}
+  `;
+
+  const { countSql } = buildBaseQueryV2(jsonParams);
+
+  return { dataSql, countSql };
+}
+
+export function buildQueryV2(jsonParams) {
+  const productTypes = jsonParams.product_types || [];
+  const blockSize = jsonParams.block_size;
+
+  if (blockSize && blockSize > 0 && productTypes.length > 1) {
+    return buildInterleavedQueryV2(jsonParams);
+  }
+
+  return buildBaseQueryV2(jsonParams);
 }
 
 export function buildQuerySingleV2(params = {}) {

--- a/src/services/ecommerce/product/utils/jewelry-v2.js
+++ b/src/services/ecommerce/product/utils/jewelry-v2.js
@@ -244,34 +244,33 @@ export function buildInterleavedQueryV2(jsonParams) {
   const productTypes = jsonParams.product_types || [];
   const blockSize = jsonParams.block_size;
 
-  const M = productTypes.length;
-  const B = blockSize;
-  const cycleSize = M * B;
+  const productTypesCount = productTypes.length;
+  const cycleSize = productTypesCount * blockSize;
 
   const from = jsonParams.pagination?.from - 1;
   const limit = jsonParams.pagination?.limit;
   const to = from + limit;
 
-  const max_rn = Math.ceil(to / cycleSize) * B;
+  const maxRowsPerType = Math.ceil(to / cycleSize) * blockSize;
 
-  const queries = productTypes.map((type, t) => {
+  const queries = productTypes.map((type, typeIdx) => {
     const singleTypeParams = {
       ...jsonParams,
       product_types: [type],
       pagination: {
         from: 1,
-        limit: max_rn
+        limit: maxRowsPerType
       }
     };
     const { dataSql: subDataSql } = buildBaseQueryV2(singleTypeParams);
-    return { subDataSql, t };
+    return { subDataSql, typeIdx };
   });
 
   const unionSql = Prisma.join(
     queries.map(q => Prisma.sql`
       SELECT *, 
-             ROW_NUMBER() OVER () as rn, 
-             ${q.t}::integer as type_idx 
+             ROW_NUMBER() OVER () as row_num, 
+             ${q.typeIdx}::integer as type_idx 
       FROM (${q.subDataSql}) AS sub_t
     `),
     " UNION ALL "
@@ -281,7 +280,7 @@ export function buildInterleavedQueryV2(jsonParams) {
     SELECT * FROM (
       ${unionSql}
     ) AS ranked
-    ORDER BY (rn - 1) / ${B}::integer ASC, type_idx ASC, rn ASC
+    ORDER BY (row_num - 1) / ${blockSize}::integer ASC, type_idx ASC, row_num ASC
     LIMIT ${limit} OFFSET ${from}
   `;
 

--- a/src/services/ecommerce/product/utils/jewelry-v2.js
+++ b/src/services/ecommerce/product/utils/jewelry-v2.js
@@ -2,8 +2,6 @@ import { aggregateQuery } from "services/ecommerce/product/utils/jewelry";
 import { JEWELRY_IMAGE, API_CONFIG } from "src/controllers/ecommerce/constant";
 import { Prisma } from "@prisma-cli";
 
-const ROW_NUM_START_INDEX = 1;
-
 export function buildInventoryMetricsSql(opts = {}) {
   if (!opts.return_inventory_metrics) {
     return Prisma.sql``;
@@ -282,7 +280,7 @@ export function buildInterleavedQueryV2(jsonParams) {
     SELECT * FROM (
       ${unionSql}
     ) AS ranked
-    ORDER BY (row_num - ${ROW_NUM_START_INDEX}) / ${blockSize}::integer ASC, type_idx ASC, row_num ASC
+    ORDER BY (row_num - ${API_CONFIG.ROW_NUM_START_INDEX}) / ${blockSize}::integer ASC, type_idx ASC, row_num ASC
     LIMIT ${limit} OFFSET ${from}
   `;
 

--- a/src/services/ecommerce/product/utils/jewelry-v2.js
+++ b/src/services/ecommerce/product/utils/jewelry-v2.js
@@ -1,6 +1,8 @@
 import { aggregateQuery } from "services/ecommerce/product/utils/jewelry";
-import { JEWELRY_IMAGE } from "src/controllers/ecommerce/constant";
+import { JEWELRY_IMAGE, API_CONFIG } from "src/controllers/ecommerce/constant";
 import { Prisma } from "@prisma-cli";
+
+const ROW_NUM_START_INDEX = 1;
 
 export function buildInventoryMetricsSql(opts = {}) {
   if (!opts.return_inventory_metrics) {
@@ -247,7 +249,7 @@ export function buildInterleavedQueryV2(jsonParams) {
   const productTypesCount = productTypes.length;
   const cycleSize = productTypesCount * blockSize;
 
-  const from = jsonParams.pagination?.from - 1;
+  const from = jsonParams.pagination?.from - API_CONFIG.MIN_FROM;
   const limit = jsonParams.pagination?.limit;
   const to = from + limit;
 
@@ -258,7 +260,7 @@ export function buildInterleavedQueryV2(jsonParams) {
       ...jsonParams,
       product_types: [type],
       pagination: {
-        from: 1,
+        from: API_CONFIG.MIN_FROM,
         limit: maxRowsPerType
       }
     };
@@ -280,7 +282,7 @@ export function buildInterleavedQueryV2(jsonParams) {
     SELECT * FROM (
       ${unionSql}
     ) AS ranked
-    ORDER BY (row_num - 1) / ${blockSize}::integer ASC, type_idx ASC, row_num ASC
+    ORDER BY (row_num - ${ROW_NUM_START_INDEX}) / ${blockSize}::integer ASC, type_idx ASC, row_num ASC
     LIMIT ${limit} OFFSET ${from}
   `;
 


### PR DESCRIPTION
- Parse `block_size` in jewelry-controller-v2.js.
- Implement querying product types separately, union them, and order by `(row_num - 1) / blockSize` to interleave blocks.
- Update jewelry-v2.js to dispatch to the interleaved query when `block_size` is active.