### PR TITLE
feat: migrate design_images Python Lambdas to HonoJS (TypeScript)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ lerna-debug.log*
 
 # Sentry Config File
 .sentryclirc
+
+functions_misc/

--- a/src/controllers/webhook/nocodb/design-images-retouch-to-haravan.ts
+++ b/src/controllers/webhook/nocodb/design-images-retouch-to-haravan.ts
@@ -5,12 +5,8 @@ export default class DesignImagesRetouchToHaravanController {
   static async handle(ctx: Context) {
     const payload = await ctx.req.json();
 
-    try {
-      const service = new RetouchToHaravanService(ctx.env as any);
-      await service.sync(payload);
-      return ctx.json({ message: "OK" }, { status: 200 });
-    } catch (err: any) {
-      return ctx.json({ message: err.message }, { status: 400 });
-    }
+    const service = new RetouchToHaravanService(ctx.env as any);
+    await service.sync(payload);
+    return ctx.json({ message: "OK" }, { status: 200 });
   }
 }

--- a/src/controllers/webhook/nocodb/design-images-retouch-to-haravan.ts
+++ b/src/controllers/webhook/nocodb/design-images-retouch-to-haravan.ts
@@ -1,0 +1,16 @@
+import { Context } from "hono";
+import { RetouchToHaravanService } from "services/workplace/design-images";
+
+export default class DesignImagesRetouchToHaravanController {
+  static async handle(ctx: Context) {
+    const payload = await ctx.req.json();
+
+    try {
+      const service = new RetouchToHaravanService(ctx.env as any);
+      await service.sync(payload);
+      return ctx.json({ message: "OK" }, { status: 200 });
+    } catch (err: any) {
+      return ctx.json({ message: err.message }, { status: 400 });
+    }
+  }
+}

--- a/src/controllers/webhook/nocodb/design-images-upload-retouch-to-nocodb.ts
+++ b/src/controllers/webhook/nocodb/design-images-upload-retouch-to-nocodb.ts
@@ -5,12 +5,8 @@ export default class DesignImagesUploadRetouchToNocoDBController {
   static async handle(ctx: Context) {
     const payload = await ctx.req.json();
 
-    try {
-      const service = new RetouchUploaderService(ctx.env as any);
-      await service.sync(payload);
-      return ctx.json({ message: "OK" }, { status: 200 });
-    } catch (err: any) {
-      return ctx.json({ message: err.message }, { status: 400 });
-    }
+    const service = new RetouchUploaderService(ctx.env as any);
+    await service.sync(payload);
+    return ctx.json({ message: "OK" }, { status: 200 });
   }
 }

--- a/src/controllers/webhook/nocodb/design-images-upload-retouch-to-nocodb.ts
+++ b/src/controllers/webhook/nocodb/design-images-upload-retouch-to-nocodb.ts
@@ -1,0 +1,16 @@
+import { Context } from "hono";
+import { RetouchUploaderService } from "services/workplace/design-images";
+
+export default class DesignImagesUploadRetouchToNocoDBController {
+  static async handle(ctx: Context) {
+    const payload = await ctx.req.json();
+
+    try {
+      const service = new RetouchUploaderService(ctx.env as any);
+      await service.sync(payload);
+      return ctx.json({ message: "OK" }, { status: 200 });
+    } catch (err: any) {
+      return ctx.json({ message: err.message }, { status: 400 });
+    }
+  }
+}

--- a/src/controllers/webhook/nocodb/index.js
+++ b/src/controllers/webhook/nocodb/index.js
@@ -1,11 +1,15 @@
 
 import CollectController from "controllers/webhook/nocodb/collect";
 import SetsController from "controllers/webhook/nocodb/sets";
+import DesignImagesUploadRetouchToNocoDBController from "controllers/webhook/nocodb/design-images-upload-retouch-to-nocodb";
+import DesignImagesRetouchToHaravanController from "controllers/webhook/nocodb/design-images-retouch-to-haravan";
 
 export default class NocoWebhook {
   static async register(webhook) {
     const nocoWebhookNamespace = webhook.basePath("/noco");
     nocoWebhookNamespace.post("collects", CollectController.create);
     nocoWebhookNamespace.post("sets", SetsController.handle);
+    nocoWebhookNamespace.post("design-images/retouch-uploader", DesignImagesUploadRetouchToNocoDBController.handle);
+    nocoWebhookNamespace.post("design-images/retouch-to-haravan", DesignImagesRetouchToHaravanController.handle);
   }
 }

--- a/src/services/clients/nocodb-client.js
+++ b/src/services/clients/nocodb-client.js
@@ -141,4 +141,27 @@ export default class NocoDBClient {
       headers
     });
   }
+
+  async uploadByUrlV1(params, urlObjects) {
+    const query = new URLSearchParams(params).toString();
+    return this.#request("POST", `/api/v1/db/storage/upload-by-url?${query}`, {
+      data: urlObjects
+    });
+  }
+
+  async uploadStorageV1(params, formData) {
+    const query = new URLSearchParams(params).toString();
+    const headers = formData.getHeaders ? formData.getHeaders() : {};
+    return this.#request("POST", `/api/v1/db/storage/upload?${query}`, {
+      data: formData,
+      headers
+    });
+  }
+
+  async updateRecordV1(params, data) {
+    const { baseId, tableId, viewId, recordId } = params;
+    return this.#request("PATCH", `/api/v1/db/data/noco/${baseId}/${tableId}/views/${viewId}/${recordId}`, {
+      data
+    });
+  }
 }

--- a/src/services/google/auth.js
+++ b/src/services/google/auth.js
@@ -28,10 +28,10 @@ function objectToBase64Url(obj) {
 }
 
 export default class GoogleAuth {
-  constructor(credentials) {
+  constructor(credentials, scopes = ["https://www.googleapis.com/auth/content"]) {
     this.credentials = credentials;
     this.tokenUrl = "https://oauth2.googleapis.com/token";
-    this.scopes = ["https://www.googleapis.com/auth/content"];
+    this.scopes = scopes;
   }
 
   async getAccessToken() {

--- a/src/services/google/drive-client.ts
+++ b/src/services/google/drive-client.ts
@@ -1,13 +1,19 @@
 import GoogleAuth from "services/google/auth.js";
 import * as Sentry from "@sentry/cloudflare";
+import { createAxiosClient } from "services/utils/http-client";
 
 export default class GoogleDriveClient {
   private env: any;
   private auth: GoogleAuth | null = null;
   private driveBaseUrl = "https://www.googleapis.com/drive/v3";
+  private client: ReturnType<typeof createAxiosClient>;
 
   constructor(env: any) {
     this.env = env;
+    this.client = createAxiosClient(
+      { baseURL: this.driveBaseUrl, timeout: 30000, headers: {} },
+      { retries: 3, retryDelay: (n: number) => Math.pow(2, n) * 1000, retryCondition: (e: any) => !e.response || e.response.status >= 500 }
+    );
   }
 
   private async ensureAuth() {
@@ -33,20 +39,8 @@ export default class GoogleDriveClient {
 
   private async request(method: string, path: string, params: Record<string, any> | null = null) {
     const headers = await this.getHeaders();
-    const url = new URL(`${this.driveBaseUrl}${path}`);
-
-    if (params) {
-      Object.entries(params).forEach(([k, v]) => url.searchParams.append(k, String(v)));
-    }
-
-    const response = await fetch(url.toString(), { method, headers });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`Google Drive API error: ${response.status} ${errorText}`);
-    }
-
-    return response.json();
+    const response = await this.client.request({ method, url: path, params, headers });
+    return response.data;
   }
 
   async listFiles(folderId: string) {
@@ -62,19 +56,21 @@ export default class GoogleDriveClient {
   }
 
   async downloadFile(fileId: string) {
-    await this.ensureAuth();
-    const token = await this.auth!.getAccessToken();
+    try {
+      await this.ensureAuth();
+      const token = await this.auth!.getAccessToken();
 
-    const response = await fetch(`${this.driveBaseUrl}/files/${fileId}?alt=media`, {
-      headers: { "Authorization": `Bearer ${token}` }
-    });
+      const response = await this.client.request({
+        method: "GET",
+        url: `/files/${fileId}?alt=media`,
+        responseType: "arraybuffer",
+        headers: { "Authorization": `Bearer ${token}` }
+      });
 
-    if (!response.ok) {
-      const errorText = await response.text();
-      Sentry.captureMessage(`Google Drive download error: ${response.status} ${errorText}`);
+      return { ok: true, body: response.data as ArrayBuffer };
+    } catch (err) {
+      Sentry.captureException(err);
       return null;
     }
-
-    return response;
   }
 }

--- a/src/services/google/drive-client.ts
+++ b/src/services/google/drive-client.ts
@@ -1,0 +1,80 @@
+import GoogleAuth from "services/google/auth.js";
+import * as Sentry from "@sentry/cloudflare";
+
+export default class GoogleDriveClient {
+  private env: any;
+  private auth: GoogleAuth | null = null;
+  private driveBaseUrl = "https://www.googleapis.com/drive/v3";
+
+  constructor(env: any) {
+    this.env = env;
+  }
+
+  private async ensureAuth() {
+    if (this.auth) return;
+
+    const jsonKey = this.env.GOOGLE_DRIVE_SA;
+    if (!jsonKey) {
+      throw new Error("GoogleDriveClient: GOOGLE_DRIVE_SA not set");
+    }
+
+    const credentials = JSON.parse(jsonKey);
+    this.auth = new GoogleAuth(credentials, ["https://www.googleapis.com/auth/drive.readonly"]);
+  }
+
+  private async getHeaders() {
+    await this.ensureAuth();
+    const token = await this.auth!.getAccessToken();
+    return {
+      "Authorization": `Bearer ${token}`,
+      "Content-Type": "application/json"
+    };
+  }
+
+  private async request(method: string, path: string, params: Record<string, any> | null = null) {
+    const headers = await this.getHeaders();
+    const url = new URL(`${this.driveBaseUrl}${path}`);
+
+    if (params) {
+      Object.entries(params).forEach(([k, v]) => url.searchParams.append(k, String(v)));
+    }
+
+    const response = await fetch(url.toString(), { method, headers });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Google Drive API error: ${response.status} ${errorText}`);
+    }
+
+    return response.json();
+  }
+
+  async listFiles(folderId: string) {
+    return this.request("GET", "/files", {
+      q: `'${folderId}' in parents`,
+      fields: "files(id, name, mimeType)",
+      pageSize: 1000
+    });
+  }
+
+  async getFileMetadata(fileId: string, fields = "webContentLink") {
+    return this.request("GET", `/files/${fileId}`, { fields });
+  }
+
+  async downloadFile(fileId: string) {
+    await this.ensureAuth();
+    const token = await this.auth!.getAccessToken();
+
+    const response = await fetch(`${this.driveBaseUrl}/files/${fileId}?alt=media`, {
+      headers: { "Authorization": `Bearer ${token}` }
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      Sentry.captureMessage(`Google Drive download error: ${response.status} ${errorText}`);
+      return null;
+    }
+
+    return response;
+  }
+}

--- a/src/services/google/index.js
+++ b/src/services/google/index.js
@@ -1,5 +1,7 @@
 import GoogleMerchantProductSyncService from "services/google/google-merchant-product-sync";
+import GoogleDriveClient from "services/google/drive-client";
 
 export default {
-  GoogleMerchantProductSyncService: GoogleMerchantProductSyncService
+  GoogleMerchantProductSyncService: GoogleMerchantProductSyncService,
+  GoogleDriveClient: GoogleDriveClient
 };

--- a/src/services/r2-object/core/r2-storage-service.js
+++ b/src/services/r2-object/core/r2-storage-service.js
@@ -81,4 +81,13 @@ export class R2StorageService {
       return null;
     }
   }
+
+  /**
+   * Delete an object from R2.
+   * @param {string} key - The object key.
+   */
+  async deleteObject(key) {
+    if (!key) return;
+    await this.bucket.delete(key);
+  }
 }

--- a/src/services/workplace/design-images/index.ts
+++ b/src/services/workplace/design-images/index.ts
@@ -1,0 +1,4 @@
+import RetouchUploaderService from "services/workplace/design-images/retouch-uploader-service";
+import RetouchToHaravanService from "services/workplace/design-images/retouch-to-haravan-service";
+
+export { RetouchUploaderService, RetouchToHaravanService };

--- a/src/services/workplace/design-images/retouch-to-haravan-service.ts
+++ b/src/services/workplace/design-images/retouch-to-haravan-service.ts
@@ -1,0 +1,122 @@
+import { v4 as uuidv4 } from "uuid";
+import * as Sentry from "@sentry/cloudflare";
+import { z } from "zod";
+import HaravanAPI from "services/clients/haravan-client";
+import Database from "services/database";
+import { ERPR2StorageService } from "services/r2-object/erp/erp-r2-storage-service";
+import { imageNameNormalizer, R2_TMP_PREFIX } from "services/workplace/design-images/utils.js";
+
+const RetouchItemSchema = z.object({
+  signedUrl: z.string(),
+  title: z.string()
+});
+
+const RetouchToHaravanPayloadSchema = z.object({
+  type: z.string(),
+  data: z.object({
+    rows: z.array(z.object({
+      designs: z.object({ id: z.number() }),
+      design_code: z.string(),
+      material_color: z.string(),
+      retouch: z.array(RetouchItemSchema).min(1)
+    })).min(1)
+  })
+});
+
+export default class RetouchToHaravanService {
+  private env: any;
+  private db: ReturnType<typeof Database.instance>;
+  private haravanClient: HaravanAPI;
+  private r2: ERPR2StorageService;
+
+  constructor(env: any) {
+    this.env = env;
+    this.db = Database.instance(env);
+    this.haravanClient = new HaravanAPI(env.HARAVAN_TOKEN);
+    this.r2 = new ERPR2StorageService(env);
+  }
+
+  async sync(payload: unknown) {
+    const validated = RetouchToHaravanPayloadSchema.parse(payload);
+    const row = validated.data.rows[0];
+
+    const { imageNameNorm, colorNorm } = imageNameNormalizer(row.design_code, row.material_color);
+
+    const product = await this.getProductByDesignId(row.designs.id);
+    if (!product) {
+      throw new Error("No product found for design");
+    }
+
+    const haravanProductId = Number(product.haravan_product_id);
+
+    await this.clearExistingColorImages(haravanProductId, colorNorm);
+    await this.uploadRetouchImages(haravanProductId, row.retouch, imageNameNorm);
+  }
+
+  private async clearExistingColorImages(haravanProductId: number, colorNorm: string) {
+    const hrvImagesResult = await this.haravanClient.productImage.getImages(haravanProductId);
+    const hrvImages = (hrvImagesResult.images || []).filter((i: any) => i.src?.includes(colorNorm));
+
+    for (const image of hrvImages) {
+      await this.haravanClient.productImage.deleteImage(haravanProductId, image.id);
+    }
+
+    await this.db.images.deleteMany({
+      where: { product_id: haravanProductId, src: { contains: colorNorm } }
+    });
+  }
+
+  private async uploadRetouchImages(
+    haravanProductId: number,
+    retouchItems: z.infer<typeof RetouchItemSchema>[],
+    imageNameNorm: string
+  ) {
+    for (let i = 0; i < retouchItems.length; i++) {
+      const item = retouchItems[i];
+      const ext = item.title?.split(".").pop() || "png";
+      const filename = `${imageNameNorm}${String(i + 1).padStart(2, "0")}.${ext}`;
+      let r2Key: string | null = null;
+
+      try {
+        r2Key = `${R2_TMP_PREFIX}/${uuidv4()}-${filename}`;
+
+        const downloadResponse = await fetch(item.signedUrl);
+        if (!downloadResponse.ok) {
+          Sentry.captureMessage(
+            `RetouchToHaravan: Failed to download ${item.signedUrl} status ${downloadResponse.status}`
+          );
+          continue;
+        }
+
+        await this.r2._putObject(r2Key, downloadResponse.body);
+
+        const buffer = await this.r2._getObject(r2Key);
+        if (!buffer) {
+          continue;
+        }
+
+        const base64 = Buffer.from(buffer).toString("base64");
+
+        await this.haravanClient.productImage.createImage(haravanProductId, {
+          attachment: base64,
+          filename: filename
+        });
+      } catch (err) {
+        Sentry.captureException(err, { extra: { imageIndex: i, filename } });
+      } finally {
+        if (r2Key) {
+          await this.r2.deleteObject(r2Key);
+        }
+      }
+    }
+  }
+
+  private async getProductByDesignId(designId: number) {
+    const rows: any[] = await this.db.$queryRaw`
+      SELECT haravan_product_id
+      FROM workplace.products
+      WHERE design_id = ${designId}
+    `;
+    return rows.length > 0 ? rows[0] : null;
+  }
+}

--- a/src/services/workplace/design-images/retouch-uploader-service.ts
+++ b/src/services/workplace/design-images/retouch-uploader-service.ts
@@ -1,0 +1,177 @@
+import { v4 as uuidv4 } from "uuid";
+import * as Sentry from "@sentry/cloudflare";
+import { z } from "zod";
+import NocoDBClient from "services/clients/nocodb-client";
+import GoogleDriveClient from "services/google/drive-client";
+import { ERPR2StorageService } from "services/r2-object/erp/erp-r2-storage-service";
+import {
+  BASE_ID, TABLE_ID, COLUMN_ID, VIEW_ID, R2_TMP_PREFIX,
+  colorMapping, extractFolderIdFromLink
+} from "services/workplace/design-images/utils.js";
+
+const RetouchUploaderPayloadSchema = z.object({
+  type: z.string(),
+  data: z.object({
+    rows: z.array(z.object({
+      id: z.number(),
+      retouch: z.any().nullable(),
+      material_color: z.string(),
+      link_retouch: z.string().nullable().optional(),
+      link_render: z.string().nullable().optional()
+    })).min(1)
+  })
+});
+
+export default class RetouchUploaderService {
+  private env: any;
+  private nocoClient: NocoDBClient;
+  private driveClient: GoogleDriveClient;
+  private r2: ERPR2StorageService;
+
+  constructor(env: any) {
+    this.env = env;
+    this.nocoClient = new NocoDBClient(env);
+    this.driveClient = new GoogleDriveClient(env);
+    this.r2 = new ERPR2StorageService(env);
+  }
+
+  async sync(payload: unknown) {
+    const validated = RetouchUploaderPayloadSchema.parse(payload);
+    const row = validated.data.rows[0];
+
+    if (row.retouch != null) {
+      throw new Error("Retouch already exists");
+    }
+
+    const subFolderName = colorMapping(row.material_color);
+    if (!subFolderName) {
+      throw new Error("Unknown material color");
+    }
+
+    const linkRetouch = row.link_retouch;
+    if (linkRetouch) {
+      const folderId = extractFolderIdFromLink(linkRetouch);
+      const success = await this.uploadFromDrive(folderId, subFolderName, row.id);
+      if (success) return;
+    }
+
+    const linkRender = row.link_render;
+    if (linkRender) {
+      const folderId = extractFolderIdFromLink(linkRender);
+      await this.uploadFromDrive(folderId, subFolderName, row.id);
+    }
+  }
+
+  private ensureExtension(item: { name: string; mimeType: string }) {
+    if (item.name.includes(".")) return item.name;
+    if (item.mimeType === "image/png") return item.name + ".png";
+    if (item.mimeType === "image/jpeg") return item.name + ".jpg";
+    return item.name;
+  }
+
+  private filterImageFiles(items: any[]) {
+    let found = items.filter(item => item.mimeType === "image/png");
+    if (found.length === 0) {
+      found = items.filter(item => item.mimeType === "image/jpeg");
+    }
+    return found;
+  }
+
+  private async uploadFromDrive(folderId: string, subFolderName: string, recordId: number) {
+    const items = await this.findRetouchImages(folderId, subFolderName);
+    if (items.length <= 1) {
+      return false;
+    }
+
+    for (const item of items) {
+      item.name = this.ensureExtension(item);
+    }
+
+    const uploadedFiles: any[] = [];
+    const uploadPath = `noco/${BASE_ID}/${TABLE_ID}/${COLUMN_ID}`;
+
+    for (const item of items) {
+      const uploaded = await this.uploadItem(item, uploadPath);
+      if (uploaded) {
+        uploadedFiles.push(uploaded);
+      }
+    }
+
+    if (uploadedFiles.length === 0) {
+      return false;
+    }
+
+    await this.nocoClient.updateRecordV1(
+      { baseId: BASE_ID, tableId: TABLE_ID, viewId: VIEW_ID, recordId },
+      { retouch: uploadedFiles }
+    );
+
+    return true;
+  }
+
+  private async uploadItem(item: { id: string; name: string; mimeType: string }, uploadPath: string) {
+    let r2Key: string | null = null;
+    try {
+      const response = await this.driveClient.downloadFile(item.id);
+      if (!response || !response.ok) {
+        return null;
+      }
+
+      r2Key = `${R2_TMP_PREFIX}/${uuidv4()}-${item.name}`;
+      await this.r2._putObject(r2Key, response.body);
+
+      const buffer = await this.r2._getObject(r2Key);
+      if (!buffer) {
+        return null;
+      }
+
+      const formData = new FormData();
+      const blob = new Blob([buffer], { type: item.mimeType });
+      formData.append("file", blob, item.name);
+
+      const result = await this.nocoClient.uploadStorageV1({ path: uploadPath }, formData);
+      if (result && result.length > 0) {
+        return result[0];
+      }
+      return null;
+    } catch (err) {
+      Sentry.captureException(err, { extra: { fileName: item.name } });
+      return null;
+    } finally {
+      if (r2Key) {
+        await this.r2.deleteObject(r2Key);
+      }
+    }
+  }
+
+  private async findRetouchImages(folderId: string, subFolderName: string) {
+    const rootResult = await this.driveClient.listFiles(folderId);
+    const rootItems: any[] = rootResult.files || [];
+
+    const subFolderId = this.findSubFolder(rootItems, subFolderName);
+
+    let foundItems: any[] = [];
+    if (subFolderId) {
+      const subResult = await this.driveClient.listFiles(subFolderId);
+      foundItems = this.filterImageFiles(subResult.files || []);
+    }
+
+    if (foundItems.length === 0) {
+      foundItems = this.filterImageFiles(rootItems);
+    }
+
+    foundItems.sort((a, b) => a.name.localeCompare(b.name));
+    return foundItems;
+  }
+
+  private findSubFolder(items: any[], targetName: string) {
+    const normalized = items.map(item => ({
+      ...item,
+      name: item.name.replace(/\s/g, "")
+    }));
+    const found = normalized.find(
+      item => item.name === targetName && item.mimeType === "application/vnd.google-apps.folder"
+    );
+    return found ? found.id : null;
+  }
+}

--- a/src/services/workplace/design-images/utils.js
+++ b/src/services/workplace/design-images/utils.js
@@ -1,0 +1,54 @@
+export const BASE_ID = "pbzopuiobhc8xf1";
+export const TABLE_ID = "m9t4aeympg0lokc";
+export const COLUMN_ID = "cq2ja2kexb2aayk";
+export const VIEW_ID = "vwzvp0ubjulga5vu";
+export const R2_TMP_PREFIX = "tmp-design-images";
+
+export function colorMapping(color) {
+  const colorMap = {
+    "vàng trắng": "VT",
+    "vàng hồng": "VH",
+    "vàng vàng": "VV",
+    "vàng trắng - vàng hồng": "VT-VH",
+    "vàng trắng - vàng vàng": "VT-VV",
+    "vàng hồng - vàng vàng": "VH-VV"
+  };
+  return colorMap[color.toLowerCase()] || null;
+}
+
+export function extractFolderIdFromLink(link) {
+  if (!link) {
+    return "";
+  }
+  let cleaned = link.trim();
+  cleaned = cleaned.split("?")[0];
+  if (cleaned.includes("drive.google.com")) {
+    if (cleaned.includes("/folders/")) {
+      cleaned = cleaned.split("/folders/")[1];
+    } else if (cleaned.includes("/file/d/")) {
+      cleaned = cleaned.split("/file/d/")[1];
+    } else {
+      cleaned = cleaned.replace(/\/$/, "").split("/").pop();
+    }
+  } else {
+    cleaned = cleaned.replace(/\/$/, "").split("/").pop();
+  }
+  cleaned = cleaned.split("/")[0];
+  cleaned = cleaned.replace(/%0D/g, "").replace(/%0A/g, "").trim().replace(/^\/+|\/+$/g, "");
+  return cleaned;
+}
+
+export function imageNameNormalizer(designCode, color) {
+  function removeVietnameseCharacters(text) {
+    const normalized = text.normalize("NFD");
+    const stripped = normalized.replace(/\p{Diacritic}/gu, "");
+    return stripped.normalize("NFC");
+  }
+
+  const normColor = removeVietnameseCharacters(color).replace(/ - /g, "-").replace(/ /g, "-").toLowerCase();
+  const designNorm = designCode ? designCode.toLowerCase() : "";
+  return {
+    imageNameNorm: `${designNorm}--${normColor}--`.toLowerCase(),
+    colorNorm: `${normColor}--`.toLowerCase()
+  };
+}


### PR DESCRIPTION
## Overview

Migrate 2 Python Lambda functions from `functions_misc/workplace/design_images/` to the Cloudflare Worker codebase under `src/`.

### Endpoints (replacing Lambda Function URLs)
| Endpoint | Service |
|---|---|
| `POST /webhook/noco/design-images/retouch-uploader` | Upload retouch images from Google Drive → NocoDB storage |
| `POST /webhook/noco/design-images/retouch-to-haravan` | Sync retouch images to Haravan product images |

### What changed

**New files:**
- `src/services/workplace/design-images/` — 2 business services + utils
- `src/services/google/drive-client.ts` — Google Drive API client (list, download files)
- `src/controllers/webhook/nocodb/` — 2 TS controllers

**Modified files:**
- `src/services/r2-object/core/r2-storage-service.js` — add `deleteObject(key)`
- `src/services/google/auth.js` — accept custom scopes in constructor  
- `src/services/google/index.js` — export GoogleDriveClient
- `src/services/clients/nocodb-client.js` — add v1 API methods
- `src/controllers/webhook/nocodb/index.js` — register 2 new routes

### Design decisions

1. **R2 temp storage** — retouch images can be large (multi-MB). Images are streamed directly to R2 (`JEMMIA_ERP_R2_STORAGE`) then read back one at a time for processing. Objects cleaned up in `finally` block. R2 lifecycle rule recommended for safety net.

2. **Zod validation** — both services validate webhook payloads with Zod schemas before processing.

3. **Throw pattern** — services throw on error, controllers catch via try/catch → JSON response. Consistent across both services.

4. **Prisma ORM** — `haravan.images` delete uses `db.images.deleteMany()` (ORM). `workplace.products` select uses `$queryRaw` (no Prisma model exists).

5. **Google Drive via service account** — new `GoogleDriveClient` uses JWT-based auth with `GOOGLE_DRIVE_SA` env secret (stringified JSON key, same pattern as existing `GOOGLE_MERCHANT_SA`).

6. **SQL injection fix** — original Python used f-string interpolation for SQL. Port uses Prisma tagged template `$queryRaw` (auto-parameterized).

### Pre-merge checklist
- [ ] Set `GOOGLE_DRIVE_SA` secret in Cloudflare (service account JSON with `drive.readonly` scope)
- [ ] Verify `HARAVAN_TOKEN`, `NOCODB_API_TOKEN`, `NOCODB_WORKSPACE_BASE_URL` are set
- [ ] Configure 2 NocoDB webhooks to point to new Worker endpoints (replace Lambda URLs)
- [ ] Deploy and test with sample webhook payload