### PR TITLE
feat: resolve product type from SKU prefix in sales order items

### DIFF
--- a/src/services/erp/selling/sales-order/sales-order.js
+++ b/src/services/erp/selling/sales-order/sales-order.js
@@ -222,6 +222,15 @@ export default class SalesOrderService {
   };
 
   mapLineItemsFields = (lineItemData) => {
+    const sku = lineItemData.sku || "";
+    let type = lineItemData.type;
+
+    if (sku.startsWith("GIA")) {
+      type = "Kim Cương Viên";
+    } else if (sku.startsWith("SPT-")) {
+      type = (lineItemData.option1 || "").split(" - ")[1] || type;
+    }
+
     return {
       doctype: this.linkedTableDoctype.lineItems,
       haravan_variant_id: lineItemData.variant_id,
@@ -233,7 +242,7 @@ export default class SalesOrderService {
       price_list_rate: parseInt(lineItemData.price_original),
       discount_amount: parseInt(lineItemData.price_original - lineItemData.price),
       rate: parseInt(lineItemData.price),
-      type: lineItemData.type
+      type
     };
   };
 


### PR DESCRIPTION
For temporary products (SPT-*), extract product type from option1 at index 1. For diamonds (GIA*), hardcode type as 'Kim Cương Viên'. For other products, use Haravan native type field.